### PR TITLE
fix/DLCL-906-dl-date-time-range-opacity

### DIFF
--- a/src/assets/globals.scss
+++ b/src/assets/globals.scss
@@ -174,6 +174,7 @@ body {
 
     --dl-date-picker-shadow: 0px 3px 6px #101e7326;
     --dl-date-picker-selected-strip: rgb(52, 82, 255, 0.2);
+    --dl-date-picker-selected-date: #8FA0FF;
 }
 
 /* Define styles for the root window with dark - mode preference */
@@ -222,6 +223,7 @@ body {
 
     --dl-date-picker-shadow: 0px 3px 6px #292e3580;
     --dl-date-picker-selected-strip: rgb(124, 140, 255, 0.2);
+    --dl-date-picker-selected-date: #535E96;
 }
 
 // scrollbar

--- a/src/components/compound/DlDateTime/DlDatePicker/components/DlCalendar.vue
+++ b/src/components/compound/DlDateTime/DlDatePicker/components/DlCalendar.vue
@@ -178,7 +178,8 @@ export default defineComponent({
 
             if (value.isDisabled) return style
 
-            const disabledOpacity = 0.6
+            const disabledOpacity = 1
+            const BACKGROUND_COLOR = '#8FA0FF'
             const isToday = value.isSame(
                 new CalendarDate().startOf('day'),
                 'day'
@@ -200,7 +201,7 @@ export default defineComponent({
                 }
             } else if (this.modelValue !== null) {
                 const selectedStyle = {
-                    backgroundColor: 'var(--dl-color-secondary)',
+                    backgroundColor: BACKGROUND_COLOR,
                     color: 'var(--dl-color-text-buttons)',
                     borderRadius: '11px'
                 }

--- a/src/components/compound/DlDateTime/DlDatePicker/components/DlCalendar.vue
+++ b/src/components/compound/DlDateTime/DlDatePicker/components/DlCalendar.vue
@@ -179,7 +179,6 @@ export default defineComponent({
             if (value.isDisabled) return style
 
             const disabledOpacity = 1
-            const BACKGROUND_COLOR = '#8FA0FF'
             const isToday = value.isSame(
                 new CalendarDate().startOf('day'),
                 'day'
@@ -201,7 +200,7 @@ export default defineComponent({
                 }
             } else if (this.modelValue !== null) {
                 const selectedStyle = {
-                    backgroundColor: BACKGROUND_COLOR,
+                    backgroundColor: 'var(--dl-date-picker-selected-date)',
                     color: 'var(--dl-color-text-buttons)',
                     borderRadius: '11px'
                 }

--- a/tests/DlDateTimeRange/DlCalendar.spec.ts
+++ b/tests/DlDateTimeRange/DlCalendar.spec.ts
@@ -25,8 +25,6 @@ const endOfWeek = new CustomDate()
     .date(15)
     .endOf('week')
 
-const BACKGROUND_COLOR = '#8FA0FF'
-
 for (let i = 1; i <= lastDayOfTheMonth; i++) {
     calendarDates.push(new CalendarDate(new Date(year, month, i)))
 }
@@ -147,7 +145,7 @@ describe('DlCalendar', () => {
         })
 
         expect(wrapper.vm.getInnerDayStyle(new CalendarDate(date))).toEqual({
-            backgroundColor: BACKGROUND_COLOR,
+            backgroundColor: 'var(--dl-date-picker-selected-date)',
             color: 'var(--dl-color-text-buttons)',
             borderRadius: '11px'
         })
@@ -192,7 +190,7 @@ describe('DlCalendar', () => {
         })
 
         expect(wrapper.vm.getInnerDayStyle(endOfWeek)).toEqual({
-            backgroundColor: BACKGROUND_COLOR,
+            backgroundColor: 'var(--dl-date-picker-selected-date)',
             borderRadius: '11px',
             color: 'var(--dl-color-text-buttons)'
         })

--- a/tests/DlDateTimeRange/DlCalendar.spec.ts
+++ b/tests/DlDateTimeRange/DlCalendar.spec.ts
@@ -25,6 +25,8 @@ const endOfWeek = new CustomDate()
     .date(15)
     .endOf('week')
 
+const BACKGROUND_COLOR = '#8FA0FF'
+
 for (let i = 1; i <= lastDayOfTheMonth; i++) {
     calendarDates.push(new CalendarDate(new Date(year, month, i)))
 }
@@ -145,7 +147,7 @@ describe('DlCalendar', () => {
         })
 
         expect(wrapper.vm.getInnerDayStyle(new CalendarDate(date))).toEqual({
-            backgroundColor: 'var(--dl-color-secondary)',
+            backgroundColor: BACKGROUND_COLOR,
             color: 'var(--dl-color-text-buttons)',
             borderRadius: '11px'
         })
@@ -190,7 +192,7 @@ describe('DlCalendar', () => {
         })
 
         expect(wrapper.vm.getInnerDayStyle(endOfWeek)).toEqual({
-            backgroundColor: 'var(--dl-color-secondary)',
+            backgroundColor: BACKGROUND_COLOR,
             borderRadius: '11px',
             color: 'var(--dl-color-text-buttons)'
         })


### PR DESCRIPTION
---------------------------------------------
| Q  | A |
| ------------- | ------------- |
| Related tickets | https://opentechdev.atlassian.net/browse/DLCL-906 |
| Vue2 |  Y |
| Vue3 |  Y |
| Storybook |  N |
| Tests |  Y |
| Demo |  N |





### Changelog


* Fix: The background color of start/end selected date has changed to #8FA0FF

------------------------