### PR TITLE
the requirements have fixed

### DIFF
--- a/src/components/basic/DlKpi/DlKpi.vue
+++ b/src/components/basic/DlKpi/DlKpi.vue
@@ -43,6 +43,7 @@
         >
             <dl-progress-bar
                 color="dl-color-darker"
+                height="5px"
                 :value="progressValue(progress)"
                 :show-value="true"
                 :show-percentage="true"
@@ -151,13 +152,13 @@ export default defineComponent({
         )
 
         const formatCounter = (counter: DlKpiCounterType) => {
-            if (!counter) {
+            if (counter === null) {
                 return emptyString
             }
             if (typeof counter === 'number') {
                 return formatNumberCounter(counter)
             }
-            if (!counter.value) {
+            if (counter.value === null || counter.value === undefined) {
                 return emptyString
             }
             if (typeof counter.value === 'number') {
@@ -197,7 +198,7 @@ export default defineComponent({
         }
 
         const formatNumberCounter = (amount: number, format = '') => {
-            if (!amount) {
+            if (isNaN(amount)) {
                 return emptyString
             }
             if (amount === 0) {

--- a/src/components/essential/DlProgressBar/DlProgressBar.vue
+++ b/src/components/essential/DlProgressBar/DlProgressBar.vue
@@ -85,6 +85,10 @@ export default defineComponent({
             type: String,
             default: '100%'
         },
+        height: {
+            type: String,
+            default: '4px'
+        },
         summary: {
             type: String,
             default: ''
@@ -102,6 +106,7 @@ export default defineComponent({
         cssVars(): Record<string, string> {
             return {
                 '--dl-progress-bar-width': `${this.computedValue}%`,
+                '--dl-progress-bar-height': `${this.height}`,
                 '--dl-progress-bar-bg': getColor(this.color)
             }
         }
@@ -109,7 +114,7 @@ export default defineComponent({
 })
 </script>
 
-<style scoped>
+<style scoped lang="scss">
 .dl-progress-bar-label {
     margin: 0;
     font-size: var(--dl-font-size-body);
@@ -119,7 +124,7 @@ export default defineComponent({
 .dl-progress-bar {
     overflow: hidden;
     width: 100%;
-    height: 4px;
+    height: var(--dl-progress-bar-height);
     border-radius: 2px;
     background-color: var(--dl-color-separator);
     margin: 6px 0;
@@ -127,7 +132,7 @@ export default defineComponent({
 .dl-progress-bar-indicator {
     transition: width 0.5s;
     display: block;
-    height: 4px;
+    height: var(--dl-progress-bar-height);
     border-radius: 2px;
     background-color: var(--dl-progress-bar-bg);
     width: var(--dl-progress-bar-width);

--- a/tests/DlProgressBar.spec.ts
+++ b/tests/DlProgressBar.spec.ts
@@ -6,13 +6,33 @@ describe('DlProgressBar', () => {
     it('should render the given label prop', () => {
         const wrapper = mount(DlProgressBar, {
             props: {
-                label: 'test label'
+                color: 'dl-color-secondary',
+                label: 'test label',
+                showValue: false,
+                showPercentage: false,
+                value: 0,
+                indeterminate: false,
+                width: '100%',
+                height: '4px',
+                summary: ''
             }
         })
 
         const label = wrapper.find('[data-test-id="progress-label"]')
             ?.element as HTMLElement
         expect(label).not.toBe(undefined)
+
+        expect(wrapper.props()).toStrictEqual({
+            color: 'dl-color-secondary',
+            label: 'test label',
+            showValue: false,
+            showPercentage: false,
+            value: 0,
+            indeterminate: false,
+            width: '100%',
+            height: '4px',
+            summary: ''
+        })
     })
     it('should accept only values between 0 and 1', () => {
         const validator = DlProgressBar.props.value.validator


### PR DESCRIPTION
---------------------------------------------
| Q  | A |
| ------------- | ------------- |
| Related tickets | https://github.com/dataloop-ai/components/issues/220 |
| Api Doc |  Y |
| Vue2 |  N |
| Vue3 |  Y |
| Storybook |  N |
| Tests |  Y |
| Demo |  N |





### Changelog


* Fix:
- the height of the DLProgressBar has increased to 5px
- the 0 is displayed as a number

### INFO  
- for numbers the counter.format field should have one of these values: 'long' or 'short'
- for time the counter.value should have '0h:0m:0s' structure and the counter.format field should have one of these values: 'hms', 'hm', 'ms', 'h', 'm', 's'

------------------------