### PR TITLE
Fixed X-Axis render issue in OA.

### DIFF
--- a/src/components/compound/DlCharts/charts/DlConfusionMatrix/DlConfusionMatrix.vue
+++ b/src/components/compound/DlCharts/charts/DlConfusionMatrix/DlConfusionMatrix.vue
@@ -295,6 +295,14 @@ export default defineComponent({
                 : getGradationValues(this.matrix)
         }
     },
+    watch: {
+        matrix: {
+            handler(value) {
+                this.currentBrushState.max = value.length
+                this.resizeMatrix()
+            }
+        }
+    },
     mounted() {
         if (!this.isValidMatrix) return
         this.resizeMatrix()


### PR DESCRIPTION
**Please provide a description of the changes proposed in the pull request and reference any related issues in the repository.**
In OA, when loading the DlConfusionMatrix component, the X-Axis labels weren't visible because `currentBrushState.max` wasn't reactive.

**Please indicate if this PR contains:**
- A bug fix
