### PR TITLE
Fix/375-dl-doughnut-chart-tooltip

### DIFF
--- a/src/components/compound/DlCharts/charts/DlDoughnutChart/DlDoughnutChart.vue
+++ b/src/components/compound/DlCharts/charts/DlDoughnutChart/DlDoughnutChart.vue
@@ -269,6 +269,23 @@ export default defineComponent({
                     plugins: {
                         legend: {
                             display: false
+                        },
+                        tooltip: {
+                            yAlign: 'none',
+                            callbacks: {
+                                labelColor (
+                                    tooltipItem: { dataIndex: string | number },
+                                    chart: any
+                                ) {
+                                    return {
+                                        backgroundColor:
+                                            chartRefValue.value.data.datasets[0]
+                                                .hoverBackgroundColor[
+                                                tooltipItem.dataIndex
+                                            ]
+                                    }
+                                }
+                            }
                         }
                     }
                 },

--- a/src/components/compound/DlCharts/charts/DlDoughnutChart/components/DlDoughnutChartLegend.vue
+++ b/src/components/compound/DlCharts/charts/DlDoughnutChart/components/DlDoughnutChartLegend.vue
@@ -15,12 +15,6 @@
                 @mouseenter="emitMouseOverLegend(index)"
                 @mouseleave="emitMouseLeaveLegend(index)"
             >
-                <dl-tooltip
-                    self="top middle"
-                    anchor="top middle"
-                >
-                    {{ data.labels[index] }}
-                </dl-tooltip>
                 <div class="wrapper__legend__item__label">
                     <div>
                         <div
@@ -28,14 +22,12 @@
                             :style="{ backgroundColor: getColor(index, badge) }"
                         />
                     </div>
-                    <dl-typography>
-                        <div
-                            :class="legendLabelClass"
-                            :style="{ color: getColor(index, text) }"
-                        >
-                            {{ data.labels[index] }}
-                        </div>
-                    </dl-typography>
+                    <div
+                        :class="legendLabelClass"
+                        :style="{ color: getColor(index, text) }"
+                    >
+                        <dl-ellipsis :text="data.labels[index]" />
+                    </div>
                 </div>
                 <div
                     class="wrapper__legend__item__counter truncate"
@@ -50,7 +42,7 @@
 
 <script lang="ts">
 import { defineComponent, PropType } from 'vue-demi'
-import { DlTypography, DlTooltip } from '../../../../../essential'
+import DlEllipsis from '../../../../../basic/DlEllipsis/DlEllipsis.vue'
 import { TDoughnutChartData } from '../types/TDoughnutChartData'
 
 enum EBadgeText {
@@ -62,8 +54,7 @@ type TBadgeText = EBadgeText.badge | EBadgeText.text
 export default defineComponent({
     name: 'DlDoughnutChartLegend',
     components: {
-        DlTypography,
-        DlTooltip
+        DlEllipsis
     },
     props: {
         data: {

--- a/tests/DlEllipsis.spec.ts
+++ b/tests/DlEllipsis.spec.ts
@@ -1,74 +1,103 @@
 import { mount } from '@vue/test-utils'
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { DlEllipsis } from '../src/components'
 
-const text =
-    'Lorem ipsum dolor sit amet consectetur adipisicing elit. Quasi corrupti rerum voluptate amet ex quas perspiciatis dicta ea similique, voluptatum perferendis possimus. Quasi eveniet asperiores, dolorum quia facilis reiciendis animi.'
+const props = {
+    text: '',
+    split: false,
+    splitPosition: 0.5,
+    tooltip: true,
+    tooltipPosition: 'top middle',
+    tooltipOffset: [0, 25]
+}
 
 describe('DlEllipsis', () => {
-    beforeEach(() => {
-        vi.resetModules()
+    it('renders the component with default props', () => {
+        const wrapper = mount(DlEllipsis)
+
+        // Assert that the leftText slot or leftText value is displayed
+        expect(wrapper.text()).toContain(wrapper.vm.leftText)
+
+        // Assert that rightText is not displayed
+        expect(wrapper.find('.dl-ellipsis__right').exists()).toBe(false)
+
+        // Assert that dl-tooltip is not displayed
+        expect(wrapper.find('dl-tooltip').exists()).toBe(false)
     })
 
-    it('should have text', async () => {
+    it('renders the component with all props', () => {
+        const text = 'Hello World'
+        const wrapper = mount(DlEllipsis, {
+            props
+        })
+        expect(wrapper.props()).toStrictEqual(props)
+    })
+
+    it('renders the component with split prop', async () => {
+        const text = 'Hello World with split prop and very long text'
         const wrapper = mount(DlEllipsis, {
             props: {
                 text,
-                split: false,
-                splitPosition: 0.75,
+                split: true
+            }
+        })
+
+        // Assert that the leftText slot or leftText value is displayed
+        expect(wrapper.text()).toContain(wrapper.vm.leftText)
+
+        // Assert that the rightText is displayed
+        expect(wrapper.text()).toContain(wrapper.vm.rightText)
+
+        // Assert that leftText and rightText are displayed
+        await expect(wrapper.find('.dl-ellipsis__left').exists()).toBe(true)
+        await expect(wrapper.find('.dl-ellipsis__right').exists()).toBe(true)
+
+        // Assert that dl-tooltip is not displayed
+        expect(wrapper.find('dl-tooltip').exists()).toBe(false)
+    })
+
+    it('renders the component with tooltip prop', () => {
+        const text = 'Hello World'
+        const wrapper = mount(DlEllipsis, {
+            props: {
+                text,
                 tooltip: true
             }
         })
 
-        expect(wrapper.exists()).toBe(true)
-        expect(wrapper.props()).toStrictEqual({
-            text,
-            split: false,
-            splitPosition: 0.75,
-            tooltip: true
-        })
+        // Assert that the leftText slot or leftText value is displayed
+        expect(wrapper.text()).toContain(wrapper.vm.leftText)
+
+        // Assert that rightText is not displayed
+        expect(wrapper.find('.dl-ellipsis__right').exists()).toBe(false)
     })
 
-    it('should to display both parts of label with middle ellipsis', () => {
+    it('renders the component with tooltip and hasEllipsis', () => {
+        const text = 'Hello World'
         const wrapper = mount(DlEllipsis, {
             props: {
                 text,
-                middleEllipsis: true
+                tooltip: true
             }
         })
 
-        const className = 'dl-ellipsis'
-        const expected = [
-            'dl-ellipsis',
-            'dl-dl-ellipsis__left',
-            'dl-dl-ellipsis__right'
-        ]
+        // Set hasEllipsis to true
+        wrapper.vm.hasEllipsis = true
 
-        const result = wrapper.classes(className)
+        // Assert that the leftText slot or leftText value is displayed
+        expect(wrapper.text()).toContain(wrapper.vm.leftText)
 
-        expected.forEach(() => {
-            expect(result).toBe(true)
-        })
+        // Assert that rightText is not displayed
+        expect(wrapper.find('.dl-ellipsis__right').exists()).toBe(false)
     })
-
-    it('should to display both parts of label without middle ellipsis', () => {
+    it('renders the component with default slot', () => {
+        const text = 'Hello World'
         const wrapper = mount(DlEllipsis, {
-            props: {
-                text
+            slots: {
+                default: text
             }
         })
 
-        const className = 'dl-ellipsis'
-        const expected = [
-            'dl-ellipsis',
-            'dl-dl-ellipsis__left',
-            'dl-dl-ellipsis__right'
-        ]
-
-        const result = wrapper.classes(className)
-
-        expected.forEach(() => {
-            expect(result).toBe(true)
-        })
+        expect(wrapper.find('.dl-ellipsis__left').text()).toContain(text)
     })
 })


### PR DESCRIPTION
---------------------------------------------
| Q  | A |
| ------------- | ------------- |
| Related tickets | https://github.com/dataloop-ai/components/issues/375 |
| Api Doc |  N |
| Vue2 |  Y |
| Vue3 |  Y |
| Storybook |  N |
| Tests |  Y |
| Demo |  N |





### Changelog


* Fix: 
-the tooltip shape has fixed and now is the same for all segments; 
-the tooltip label color has fixed and now has the segment color; 
-the legend label has tooltip if it has ellipsis

------------------------

