### PR TITLE
#298-dl-input - fixed no red border when error='true'

### DIFF
--- a/src/components/compound/DlInput/DlInput.vue
+++ b/src/components/compound/DlInput/DlInput.vue
@@ -745,13 +745,19 @@ export default defineComponent({
 
         &--error {
             border-color: var(--dl-color-negative);
+
+            &:focus {
+                border-color: var(--dl-color-negative) !important;
+            }
+
             &:hover {
-                border-color: var(--dl-color-separator) !important;
+                border-color: var(--dl-color-negative) !important;
             }
         }
 
         &--warning {
             border-color: var(--dl-color-warning);
+
             &:hover {
                 border-color: var(--dl-color-separator) !important;
             }
@@ -775,9 +781,11 @@ export default defineComponent({
             color: var(--dl-color-disabled);
             cursor: not-allowed;
         }
+
         &:read-only {
             border-color: var(--dl-color-separator);
             cursor: text;
+
             &:hover {
                 border-color: var(--dl-color-separator) !important;
             }
@@ -812,6 +820,7 @@ export default defineComponent({
             top: 0;
             right: 0;
         }
+
         &--pos-right-out {
             top: 0;
             right: -30px;


### PR DESCRIPTION
**Thank you for your contribution to the repo. Before submitting this PR, please make sure:**
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests
- [ ] You have updated documentation
- [ ] You have tested your changes

**Please provide a description of the changes proposed in the pull request and reference any related issues in the repository.**

**Please indicate if this PR contains:**
- [ ] A bug fix
- [ ] A feature request
- [ ] Breaking changes
- [ ] An enhancement
