### PR TITLE
Model value handling

### DIFF
--- a/src/components/basic/DlAccordion/DlAccordion.vue
+++ b/src/components/basic/DlAccordion/DlAccordion.vue
@@ -60,7 +60,7 @@ export default defineComponent({
         DlEmptyState
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/basic/DlAlert/DlAlert.vue
+++ b/src/components/basic/DlAlert/DlAlert.vue
@@ -80,7 +80,7 @@ export default defineComponent({
         DlIcon
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/basic/DlGrid/DlGrid.vue
+++ b/src/components/basic/DlGrid/DlGrid.vue
@@ -20,7 +20,7 @@ import {
 
 export default defineComponent({
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/basic/DlGrid/DlGrid.vue
+++ b/src/components/basic/DlGrid/DlGrid.vue
@@ -21,7 +21,7 @@ import {
 export default defineComponent({
     model: {
         prop: 'modelValue',
-        event: 'update:modelValue'
+        event: 'update:model-value'
     },
     props: {
         modelValue: {
@@ -41,7 +41,7 @@ export default defineComponent({
             default: 3
         }
     },
-    emits: ['update:modelValue', 'layout-changed'],
+    emits: ['update:model-value', 'layout-changed'],
     computed: {
         gridStyles(): object {
             return {
@@ -129,7 +129,7 @@ export default defineComponent({
                 this.maxElementsPerRow
             )
             // Update modelValue is required to trigger visualization of the changes
-            this.$emit('update:modelValue', newLayout)
+            this.$emit('update:model-value', newLayout)
             if (e.detail.endDragging) {
                 this.layoutChanged()
             }

--- a/src/components/basic/DlPanelContainer/DlPanelContainer.vue
+++ b/src/components/basic/DlPanelContainer/DlPanelContainer.vue
@@ -139,7 +139,7 @@ export default defineComponent({
         DlEmptyState
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/basic/DlPopup/DlPopup.vue
+++ b/src/components/basic/DlPopup/DlPopup.vue
@@ -142,7 +142,7 @@ export default defineComponent({
         DlEmptyState
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlCharts/components/DlBrush.vue
+++ b/src/components/compound/DlCharts/components/DlBrush.vue
@@ -78,7 +78,7 @@ export default defineComponent({
     },
     model: {
         prop: 'modelValue',
-        event: 'update:modelValue'
+        event: 'update:model-value'
     },
     props: {
         ...useSliderProps,

--- a/src/components/compound/DlCharts/components/DlBrush.vue
+++ b/src/components/compound/DlCharts/components/DlBrush.vue
@@ -77,7 +77,7 @@ export default defineComponent({
         BrushThumb
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlCodeEditor/DlCodeEditor.vue
+++ b/src/components/compound/DlCodeEditor/DlCodeEditor.vue
@@ -33,7 +33,7 @@ export default defineComponent({
         CodeEditor
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlCodeEditor/components/CodeEditor.vue
+++ b/src/components/compound/DlCodeEditor/components/CodeEditor.vue
@@ -136,7 +136,7 @@ export default defineComponent({
         DlButton
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlDateTime/DlDatePicker/DlDatePicker.vue
+++ b/src/components/compound/DlDateTime/DlDatePicker/DlDatePicker.vue
@@ -17,7 +17,7 @@
                     :disabled="disabled"
                     :with-left-chevron="true"
                     @prev="handleDatePrev"
-                    @update:modelValue="updateDateInterval"
+                    @update:model-value="updateDateInterval"
                     @mousedown="handleMousedown"
                     @mouseenter="handleMouseenter"
                 />
@@ -32,7 +32,7 @@
                     :disabled="disabled"
                     :with-right-chevron="true"
                     @next="handleDateNext"
-                    @update:modelValue="updateDateInterval"
+                    @update:model-value="updateDateInterval"
                     @mousedown="handleMousedown"
                     @mouseenter="handleMouseenter"
                 />
@@ -49,7 +49,7 @@
                     :available-range="availableRange"
                     :disabled="disabled"
                     :with-left-chevron="true"
-                    @update:modelValue="updateDateInterval"
+                    @update:model-value="updateDateInterval"
                     @prev="handleMonthPrev"
                     @mousedown="handleMousedown"
                     @mouseenter="handleMouseenter"
@@ -62,7 +62,7 @@
                     :available-range="availableRange"
                     :disabled="disabled"
                     :with-right-chevron="true"
-                    @update:modelValue="updateDateInterval"
+                    @update:model-value="updateDateInterval"
                     @next="handleMonthNext"
                     @mousedown="handleMousedown"
                     @mouseenter="handleMouseenter"
@@ -87,7 +87,7 @@ export default defineComponent({
         DlMonthCalendar
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlDateTime/DlDatePicker/DlDatePicker.vue
+++ b/src/components/compound/DlDateTime/DlDatePicker/DlDatePicker.vue
@@ -88,7 +88,7 @@ export default defineComponent({
     },
     model: {
         prop: 'modelValue',
-        event: 'update:modelValue'
+        event: 'update:model-value'
     },
     props: {
         modelValue: {
@@ -110,7 +110,7 @@ export default defineComponent({
         normalizeCalendars: Boolean,
         disabled: Boolean
     },
-    emits: ['update:modelValue', 'change'],
+    emits: ['update:model-value', 'change'],
     data(): {
         uuid: string
         timeout: number | null
@@ -193,7 +193,7 @@ export default defineComponent({
         },
         updateModelValue(value: DateInterval) {
             if (this.disabled) return
-            this.$emit('update:modelValue', value)
+            this.$emit('update:model-value', value)
             this.$emit('change', value)
         },
 

--- a/src/components/compound/DlDateTime/DlDatePicker/components/DlCalendar.vue
+++ b/src/components/compound/DlDateTime/DlDatePicker/components/DlCalendar.vue
@@ -72,7 +72,7 @@ export default defineComponent({
     },
     model: {
         prop: 'modelValue',
-        event: 'update:modelValue'
+        event: 'update:model-value'
     },
     props: {
         title: {
@@ -96,7 +96,7 @@ export default defineComponent({
         disabled: Boolean
     },
     emits: [
-        'update:modelValue',
+        'update:model-value',
         'change',
         'mousedown',
         'mouseenter',
@@ -127,7 +127,7 @@ export default defineComponent({
                 to: value.toDate()
             }
 
-            this.$emit('update:modelValue', newDate)
+            this.$emit('update:model-value', newDate)
             this.$emit('change', newDate)
         },
         getDayStyle(value: Partial<CalendarDate>) {

--- a/src/components/compound/DlDateTime/DlDatePicker/components/DlCalendar.vue
+++ b/src/components/compound/DlDateTime/DlDatePicker/components/DlCalendar.vue
@@ -71,7 +71,7 @@ export default defineComponent({
         DlIcon
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlDateTime/DlDatePicker/components/DlMonthCalendar.vue
+++ b/src/components/compound/DlDateTime/DlDatePicker/components/DlMonthCalendar.vue
@@ -54,7 +54,7 @@ export default defineComponent({
     },
     model: {
         prop: 'modelValue',
-        event: 'update:modelValue'
+        event: 'update:model-value'
     },
     props: {
         title: {
@@ -74,7 +74,7 @@ export default defineComponent({
         disabled: Boolean
     },
     emits: [
-        'update:modelValue',
+        'update:model-value',
         'change',
         'mousedown',
         'mouseenter',
@@ -109,7 +109,7 @@ export default defineComponent({
                 from: date,
                 to: date
             }
-            this.$emit('update:modelValue', newDate)
+            this.$emit('update:model-value', newDate)
             this.$emit('change', newDate)
         },
 

--- a/src/components/compound/DlDateTime/DlDatePicker/components/DlMonthCalendar.vue
+++ b/src/components/compound/DlDateTime/DlDatePicker/components/DlMonthCalendar.vue
@@ -53,7 +53,7 @@ export default defineComponent({
         DlIcon
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlDateTime/DlDateTimeRange/DlDateTimeRange.vue
+++ b/src/components/compound/DlDateTime/DlDateTimeRange/DlDateTimeRange.vue
@@ -86,7 +86,7 @@ export default defineComponent({
     },
     model: {
         prop: 'modelValue',
-        event: 'update:modelValue'
+        event: 'update:model-value'
     },
     props: {
         modelValue: {
@@ -118,7 +118,7 @@ export default defineComponent({
             default: 'Set Due Date'
         }
     },
-    emits: ['update:modelValue', 'set-type', 'change'],
+    emits: ['update:model-value', 'set-type', 'change'],
     data(): {
         uuid: string
         dateInterval: DateInterval | null
@@ -426,7 +426,7 @@ export default defineComponent({
                     59
                 )
             }
-            this.$emit('update:modelValue', value)
+            this.$emit('update:model-value', value)
             this.$emit('change', value)
         },
         updateDateIntervalWithAutoClose(value: DateInterval) {

--- a/src/components/compound/DlDateTime/DlDateTimeRange/DlDateTimeRange.vue
+++ b/src/components/compound/DlDateTime/DlDateTimeRange/DlDateTimeRange.vue
@@ -43,13 +43,15 @@
                             :available-range="availableRange"
                             :disabled="isInputDisabled"
                             :normalize-calendars="normalizeCalendars"
-                            @update:modelValue="updateDateIntervalWithAutoClose"
+                            @update:model-value="
+                                updateDateIntervalWithAutoClose
+                            "
                         />
                         <dl-time-picker
                             v-if="showTime && typeState === 'day'"
                             :disabled="isInputDisabled"
                             :model-value="dateInterval"
-                            @update:modelValue="updateDateInterval"
+                            @update:model-value="updateDateInterval"
                         />
                     </div>
                 </div>
@@ -85,7 +87,7 @@ export default defineComponent({
         DlMenu
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlDateTime/DlTimePicker/DlTimePicker.vue
+++ b/src/components/compound/DlDateTime/DlTimePicker/DlTimePicker.vue
@@ -49,7 +49,7 @@ export default defineComponent({
         },
         disabled: Boolean
     },
-    emits: ['update:modelValue'],
+    emits: ['update:model-value'],
     data() {
         return {
             uuid: `dl-time-picker-${v4()}`
@@ -104,7 +104,7 @@ export default defineComponent({
             newFrom.hours(parseInt(value.hour)).minutes(parseInt(value.minute))
 
             if (newFrom.isBefore(new CustomDate(this.modelValue.to))) {
-                this.$emit('update:modelValue', {
+                this.$emit('update:model-value', {
                     from: newFrom.toDate(),
                     to: this.modelValue.to
                 })
@@ -116,7 +116,7 @@ export default defineComponent({
             newTo.hours(parseInt(value.hour)).minutes(parseInt(value.minute))
 
             if (newTo.isAfter(new CustomDate(this.modelValue.from))) {
-                this.$emit('update:modelValue', {
+                this.$emit('update:model-value', {
                     from: this.modelValue.from,
                     to: newTo.toDate()
                 })

--- a/src/components/compound/DlDateTime/DlTimePicker/DlTimePicker.vue
+++ b/src/components/compound/DlDateTime/DlTimePicker/DlTimePicker.vue
@@ -11,7 +11,7 @@
             <dl-time-picker-input
                 :disabled="disableInput"
                 :model-value="formatedFromValue"
-                @update:modelValue="handleFromTimeChange"
+                @update:model-value="handleFromTimeChange"
             />
         </div>
         <div class="dl-time-picker--dash">
@@ -25,7 +25,7 @@
             <dl-time-picker-input
                 :disabled="disableInput"
                 :model-value="formatedToValue"
-                @update:modelValue="handleToTimeChange"
+                @update:model-value="handleToTimeChange"
             />
         </div>
     </div>

--- a/src/components/compound/DlDateTime/DlTimePicker/components/DlTimePickerInput.vue
+++ b/src/components/compound/DlDateTime/DlTimePicker/components/DlTimePickerInput.vue
@@ -97,7 +97,7 @@ export default defineComponent({
         },
         disabled: Boolean
     },
-    emits: ['update:modelValue'],
+    emits: ['update:model-value'],
     data(): {
         options: Time[]
     } {
@@ -230,14 +230,14 @@ export default defineComponent({
         },
 
         handleHourChange(value: string) {
-            this.$emit('update:modelValue', {
+            this.$emit('update:model-value', {
                 hour: value,
                 minute: this.modelValue.minute
             })
         },
 
         handleMinuteChange(value: string) {
-            this.$emit('update:modelValue', {
+            this.$emit('update:model-value', {
                 hour: this.modelValue.hour,
                 minute: value
             })

--- a/src/components/compound/DlDialogBox/DlDialogBox.vue
+++ b/src/components/compound/DlDialogBox/DlDialogBox.vue
@@ -92,7 +92,7 @@ export default defineComponent({
     components: { DlIcon, DlEmptyState },
     model: {
         prop: 'modelValue',
-        event: 'update:modelValue'
+        event: 'update:model-value'
     },
     props: {
         width: { type: [Number, String], default: 400 },
@@ -120,7 +120,7 @@ export default defineComponent({
             default: 'var(--dl-z-index-dialog)'
         }
     },
-    emits: ['update:modelValue', 'hide', 'show'],
+    emits: ['update:model-value', 'hide', 'show'],
     data(): {
         uuid: string
         show: boolean
@@ -224,7 +224,7 @@ export default defineComponent({
                 (this.$el as HTMLElement).blur()
             }
             this.show = false
-            this.$emit('update:modelValue', false)
+            this.$emit('update:model-value', false)
             if (!this.hasParent) {
                 document.documentElement.style.overflow = 'auto'
             }
@@ -234,7 +234,7 @@ export default defineComponent({
         },
         openModal() {
             this.show = true
-            this.$emit('update:modelValue', true)
+            this.$emit('update:model-value', true)
             if (!this.hasParent) {
                 document.documentElement.style.overflow = 'hidden'
             }

--- a/src/components/compound/DlDialogBox/DlDialogBox.vue
+++ b/src/components/compound/DlDialogBox/DlDialogBox.vue
@@ -91,7 +91,7 @@ export default defineComponent({
     name: 'DlDialogBox',
     components: { DlIcon, DlEmptyState },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlDropdownButton/DlDropdownButton.vue
+++ b/src/components/compound/DlDropdownButton/DlDropdownButton.vue
@@ -199,7 +199,7 @@ export default defineComponent({
         ButtonGroup
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlDropdownButton/DlDropdownButton.vue
+++ b/src/components/compound/DlDropdownButton/DlDropdownButton.vue
@@ -257,7 +257,7 @@ export default defineComponent({
     },
     emits: [
         'update:model-value',
-        'update:modelValue',
+        'update:model-value',
         'click',
         'before-show',
         'show',
@@ -293,7 +293,7 @@ export default defineComponent({
 
         const menuModel = computed({
             get: () => props.modelValue,
-            set: (val) => emit('update:modelValue', val)
+            set: (val) => emit('update:model-value', val)
         })
 
         const iconClass = computed(() => {
@@ -344,7 +344,7 @@ export default defineComponent({
 
         function onShow(e: Event) {
             emit('show', e)
-            emit('update:modelValue', true)
+            emit('update:model-value', true)
         }
 
         function onBeforeHide(e: Event) {
@@ -354,7 +354,7 @@ export default defineComponent({
 
         function onHide(e: Event) {
             emit('hide', e)
-            emit('update:modelValue', false)
+            emit('update:model-value', false)
         }
 
         function onClick(e: Event) {

--- a/src/components/compound/DlInput/DlInput.vue
+++ b/src/components/compound/DlInput/DlInput.vue
@@ -229,7 +229,7 @@ export default defineComponent({
         DlListItem
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlJsonEditor/DlJsonEditor.vue
+++ b/src/components/compound/DlJsonEditor/DlJsonEditor.vue
@@ -12,7 +12,7 @@ import { debounce } from 'lodash'
 
 export default defineComponent({
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlJsonEditor/DlJsonEditor.vue
+++ b/src/components/compound/DlJsonEditor/DlJsonEditor.vue
@@ -13,7 +13,7 @@ import { debounce } from 'lodash'
 export default defineComponent({
     model: {
         prop: 'modelValue',
-        event: 'update:modelValue'
+        event: 'update:model-value'
     },
     props: {
         /**
@@ -32,7 +32,7 @@ export default defineComponent({
             default: null
         }
     },
-    emits: ['update:modelValue', 'update-prevent', 'align-text'],
+    emits: ['update:model-value', 'update-prevent', 'align-text'],
     data() {
         return {
             jsonEditor: {} as JSONEditor,
@@ -62,7 +62,7 @@ export default defineComponent({
                             this.preventOnChange = false
                             return
                         }
-                        this.$emit('update:modelValue', updatedContent.text)
+                        this.$emit('update:model-value', updatedContent.text)
                         if (this.preventUpdate !== null) {
                             this.$emit('update-prevent', true)
                         }

--- a/src/components/compound/DlOptionGroup/DlOptionGroup.vue
+++ b/src/components/compound/DlOptionGroup/DlOptionGroup.vue
@@ -70,7 +70,7 @@ export default defineComponent({
         DlTooltip
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlPagination/DlPagination.vue
+++ b/src/components/compound/DlPagination/DlPagination.vue
@@ -28,7 +28,7 @@
                     :active-color="activeColor"
                     :text-color="textColor"
                     :active-text-color="activeTextColor"
-                    @update:modelValue="setValue"
+                    @update:model-value="setValue"
                 />
                 <quick-navigation
                     v-if="withQuickNavigation"
@@ -36,7 +36,7 @@
                     :max="max"
                     :min="min"
                     :disabled="disabled"
-                    @update:modelValue="setValue"
+                    @update:model-value="setValue"
                 />
             </div>
             <pagination-legend
@@ -67,7 +67,7 @@ export default defineComponent({
         PaginationLegend
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlPagination/DlPagination.vue
+++ b/src/components/compound/DlPagination/DlPagination.vue
@@ -68,7 +68,7 @@ export default defineComponent({
     },
     model: {
         prop: 'modelValue',
-        event: 'update:modelValue'
+        event: 'update:model-value'
     },
     props: {
         modelValue: {
@@ -124,7 +124,7 @@ export default defineComponent({
         withRowsPerPage: Boolean,
         withLegend: Boolean
     },
-    emits: ['update:modelValue', 'update:rowsPerPage'],
+    emits: ['update:model-value', 'update:rowsPerPage'],
     data() {
         return {
             uuid: `dl-pagination-${v4()}`,
@@ -167,7 +167,7 @@ export default defineComponent({
     methods: {
         setValue(value: number) {
             this.value = value
-            this.$emit('update:modelValue', value)
+            this.$emit('update:model-value', value)
         }
     }
 })

--- a/src/components/compound/DlPagination/components/PageNavigation.vue
+++ b/src/components/compound/DlPagination/components/PageNavigation.vue
@@ -113,7 +113,7 @@ export default defineComponent({
     },
     model: {
         prop: 'modelValue',
-        event: 'update:modelValue'
+        event: 'update:model-value'
     },
     props: {
         modelValue: {
@@ -155,7 +155,7 @@ export default defineComponent({
             default: 'dl-color-text-buttons'
         }
     },
-    emits: ['update:modelValue'],
+    emits: ['update:model-value'],
     data() {
         return {
             value: this.modelValue,
@@ -229,7 +229,7 @@ export default defineComponent({
         },
         setPage(value: number) {
             this.set(value)
-            this.$emit('update:modelValue', value)
+            this.$emit('update:model-value', value)
         },
         updateState() {
             this.ellipsesStart = false

--- a/src/components/compound/DlPagination/components/PageNavigation.vue
+++ b/src/components/compound/DlPagination/components/PageNavigation.vue
@@ -112,7 +112,7 @@ export default defineComponent({
         DlIcon
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlPagination/components/QuickNavigation.vue
+++ b/src/components/compound/DlPagination/components/QuickNavigation.vue
@@ -38,7 +38,7 @@ export default defineComponent({
         DlButton
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlPagination/components/QuickNavigation.vue
+++ b/src/components/compound/DlPagination/components/QuickNavigation.vue
@@ -39,7 +39,7 @@ export default defineComponent({
     },
     model: {
         prop: 'modelValue',
-        event: 'update:modelValue'
+        event: 'update:model-value'
     },
     props: {
         modelValue: { type: Number, required: true },
@@ -47,7 +47,7 @@ export default defineComponent({
         max: { type: Number, required: true },
         disabled: Boolean
     },
-    emits: ['update:modelValue'],
+    emits: ['update:model-value'],
     data() {
         return {
             inputValue: this.modelValue.toString(),
@@ -71,7 +71,7 @@ export default defineComponent({
                 this.inputValue = this.max.toString()
             }
 
-            this.$emit('update:modelValue', Number(this.inputValue))
+            this.$emit('update:model-value', Number(this.inputValue))
         },
         handleKeyDown(e: KeyboardEvent) {
             if (

--- a/src/components/compound/DlPagination/components/RowsSelector.vue
+++ b/src/components/compound/DlPagination/components/RowsSelector.vue
@@ -35,7 +35,7 @@ export default defineComponent({
     },
     model: {
         prop: 'modelValue',
-        event: 'update:modelValue'
+        event: 'update:model-value'
     },
     props: {
         options: {
@@ -52,7 +52,7 @@ export default defineComponent({
         },
         disabled: Boolean
     },
-    emits: ['update:modelValue'],
+    emits: ['update:model-value'],
     computed: {
         hasSingeValue(): boolean {
             return this.options.length <= 1
@@ -60,7 +60,7 @@ export default defineComponent({
     },
     methods: {
         setSelectedItem(val: number) {
-            this.$emit('update:modelValue', val)
+            this.$emit('update:model-value', val)
         }
     }
 })

--- a/src/components/compound/DlPagination/components/RowsSelector.vue
+++ b/src/components/compound/DlPagination/components/RowsSelector.vue
@@ -34,7 +34,7 @@ export default defineComponent({
         DlTypography
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlRange/DlRange.vue
+++ b/src/components/compound/DlRange/DlRange.vue
@@ -114,7 +114,7 @@ export default defineComponent({
         touchPan: touchPanDirective as any // force any type cause of the vue version
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlSearches/DlSearch/DlSearch.vue
+++ b/src/components/compound/DlSearches/DlSearch/DlSearch.vue
@@ -70,7 +70,7 @@ export default defineComponent({
         DlInput
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlSearches/DlSmartSearch/DlSmartSearch.vue
+++ b/src/components/compound/DlSearches/DlSmartSearch/DlSmartSearch.vue
@@ -262,7 +262,7 @@ export default defineComponent({
     },
     model: {
         prop: 'modelValue',
-        event: 'update:modelValue'
+        event: 'update:model-value'
     },
     props: {
         modelValue: {
@@ -321,7 +321,7 @@ export default defineComponent({
             default: false
         }
     },
-    emits: ['save-query', 'remove-query', 'search-query', 'update:modelValue'],
+    emits: ['save-query', 'remove-query', 'search-query', 'update:model-value'],
     setup(props, { emit }) {
         const inputModel = ref('')
         const jsonEditorModel = ref(false)
@@ -362,7 +362,7 @@ export default defineComponent({
             const cleanedAliases = revertAliases(bracketless, props.aliases)
             const json = toJSON(cleanedAliases)
             if (!isEqual(json, props.modelValue)) {
-                emit('update:modelValue', json)
+                emit('update:model-value', json)
             }
             const stringified = JSON.stringify(json)
             activeQuery.value.query = stringified

--- a/src/components/compound/DlSearches/DlSmartSearch/DlSmartSearch.vue
+++ b/src/components/compound/DlSearches/DlSmartSearch/DlSmartSearch.vue
@@ -23,7 +23,7 @@
                 :default-width="width"
                 @save="saveQueryDialogBoxModel = true"
                 @focus="setFocused"
-                @update:modelValue="debouncedInputModel"
+                @update:model-value="debouncedInputModel"
                 @dql-edit="jsonEditorModel = !jsonEditorModel"
             />
         </div>
@@ -261,7 +261,7 @@ export default defineComponent({
         DlSelect
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {
@@ -445,7 +445,7 @@ export default defineComponent({
             }
         }
 
-        const modelRef = toRef(props, 'modelValue')
+        const modelRef = toRef(props, 'model-value')
 
         watch(modelRef, (val: any) => {
             readModelValue(val)

--- a/src/components/compound/DlSearches/DlSmartSearch/DlSmartSearch.vue
+++ b/src/components/compound/DlSearches/DlSmartSearch/DlSmartSearch.vue
@@ -445,7 +445,7 @@ export default defineComponent({
             }
         }
 
-        const modelRef = toRef(props, 'model-value')
+        const modelRef = toRef(props, 'modelValue')
 
         watch(modelRef, (val: any) => {
             readModelValue(val)

--- a/src/components/compound/DlSearches/DlSmartSearch/components/DlSmartSearchInput.vue
+++ b/src/components/compound/DlSearches/DlSmartSearch/components/DlSmartSearchInput.vue
@@ -159,7 +159,7 @@ export default defineComponent({
     },
     model: {
         prop: 'modelValue',
-        event: 'update:modelValue'
+        event: 'update:model-value'
     },
     props: {
         status: {
@@ -224,7 +224,7 @@ export default defineComponent({
         }
     },
     emits: [
-        'update:modelValue',
+        'update:model-value',
         'update:expanded',
         'save',
         'search',
@@ -307,7 +307,7 @@ export default defineComponent({
                 }
             }
 
-            emit('update:modelValue', stringValue)
+            emit('update:model-value', stringValue)
         }
 
         const debouncedSetModal = debounce(
@@ -570,7 +570,7 @@ export default defineComponent({
         },
         clearValue() {
             this.cancelBlur = this.cancelBlur === 0 ? 1 : this.cancelBlur
-            this.$emit('update:modelValue', '')
+            this.$emit('update:model-value', '')
             if (!this.focused) {
                 this.focus()
             }
@@ -591,7 +591,7 @@ export default defineComponent({
                 .toString()
                 .replaceAll(' ', ' ')
 
-            this.$emit('update:modelValue', text)
+            this.$emit('update:model-value', text)
         },
         handleScreenButtonClick() {
             this.cancelBlur = this.cancelBlur === 0 ? 1 : this.cancelBlur
@@ -604,7 +604,7 @@ export default defineComponent({
             this.datePickerSelection = val
 
             this.$emit(
-                'update:modelValue',
+                'update:model-value',
                 replaceDateInterval(this.modelValue, val)
             )
         }

--- a/src/components/compound/DlSearches/DlSmartSearch/components/DlSmartSearchInput.vue
+++ b/src/components/compound/DlSearches/DlSmartSearch/components/DlSmartSearchInput.vue
@@ -158,7 +158,7 @@ export default defineComponent({
         DlMenu
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlSearches/DlSmartSearch/components/DlSuggestionsDropdown.vue
+++ b/src/components/compound/DlSearches/DlSmartSearch/components/DlSuggestionsDropdown.vue
@@ -43,7 +43,7 @@ export default defineComponent({
         DlListItem
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {
@@ -90,6 +90,7 @@ export default defineComponent({
             handleOption(value)
         }
         const emitModelValue = (event: any) => {
+            console.log('emit suggestion model change')
             emit('update:model-value', event)
         }
         const handleOption = (item: any) => {

--- a/src/components/compound/DlSearches/DlSmartSearch/components/DlSuggestionsDropdown.vue
+++ b/src/components/compound/DlSearches/DlSmartSearch/components/DlSuggestionsDropdown.vue
@@ -44,7 +44,7 @@ export default defineComponent({
     },
     model: {
         prop: 'modelValue',
-        event: 'update:modelValue'
+        event: 'update:model-value'
     },
     props: {
         parentId: {
@@ -72,7 +72,7 @@ export default defineComponent({
             default: () => [0, 0]
         }
     },
-    emits: ['set-input-value', 'update:modelValue'],
+    emits: ['set-input-value', 'update:model-value'],
     setup(props, { emit }) {
         const isMenuOpen = ref(false)
         const highlightedIndex = ref(-1)
@@ -90,7 +90,7 @@ export default defineComponent({
             handleOption(value)
         }
         const emitModelValue = (event: any) => {
-            emit('update:modelValue', event)
+            emit('update:model-value', event)
         }
         const handleOption = (item: any) => {
             emit('set-input-value', item)

--- a/src/components/compound/DlSelect/DlSelect.vue
+++ b/src/components/compound/DlSelect/DlSelect.vue
@@ -344,7 +344,7 @@ export default defineComponent({
         DlVirtualScroll
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlSelect/components/DlSelectOption.vue
+++ b/src/components/compound/DlSelect/components/DlSelectOption.vue
@@ -116,7 +116,7 @@ export default defineComponent({
         DlIcon
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlSlider/DlSlider.vue
+++ b/src/components/compound/DlSlider/DlSlider.vue
@@ -113,7 +113,7 @@ export default defineComponent({
         DlIcon
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlSlider/components/DlSliderBase.vue
+++ b/src/components/compound/DlSlider/components/DlSliderBase.vue
@@ -58,7 +58,7 @@ export default defineComponent({
         touchPan: touchPanDirective as any // force any type cause of the vue version
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlSlider/components/DlSliderInput.vue
+++ b/src/components/compound/DlSlider/components/DlSliderInput.vue
@@ -20,7 +20,7 @@ import { getInputValue } from '../utils'
 export default defineComponent({
     name: 'DlSliderInput',
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {
@@ -47,7 +47,7 @@ export default defineComponent({
     },
     emits: ['update:model-value', 'change'],
     setup(props, { emit }) {
-        const modelRef = toRef(props, 'modelValue')
+        const modelRef = toRef(props, 'model-value')
 
         const handleChange = (evt: any) => {
             const val = evt.target.value

--- a/src/components/compound/DlSlider/components/DlSliderInput.vue
+++ b/src/components/compound/DlSlider/components/DlSliderInput.vue
@@ -47,7 +47,7 @@ export default defineComponent({
     },
     emits: ['update:model-value', 'change'],
     setup(props, { emit }) {
-        const modelRef = toRef(props, 'model-value')
+        const modelRef = toRef(props, 'modelValue')
 
         const handleChange = (evt: any) => {
             const val = evt.target.value

--- a/src/components/compound/DlStepper/DlStepper.vue
+++ b/src/components/compound/DlStepper/DlStepper.vue
@@ -97,7 +97,7 @@ export default defineComponent({
         DlEmptyState
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlStepper/DlStepper.vue
+++ b/src/components/compound/DlStepper/DlStepper.vue
@@ -98,7 +98,7 @@ export default defineComponent({
     },
     model: {
         prop: 'modelValue',
-        event: 'update:modelValue'
+        event: 'update:model-value'
     },
     props: {
         steps: {
@@ -163,7 +163,7 @@ export default defineComponent({
             default: null
         }
     },
-    emits: ['update:modelValue', 'done', 'next', 'prev', 'set-step', 'close'],
+    emits: ['update:model-value', 'done', 'next', 'prev', 'set-step', 'close'],
     data() {
         return {
             uuid: `dl-stepper-${v4()}`,
@@ -207,7 +207,7 @@ export default defineComponent({
     methods: {
         closeStepper() {
             this.$emit('close')
-            this.$emit('update:modelValue', false)
+            this.$emit('update:model-value', false)
         }
     }
 })

--- a/src/components/compound/DlTabPanels/DlTabPanels.vue
+++ b/src/components/compound/DlTabPanels/DlTabPanels.vue
@@ -6,7 +6,7 @@ import { textSlot } from '../../../utils/render'
 export default defineComponent({
     name: 'DlTabPanels',
     model: {
-        prop: 'modelValue'
+        prop: 'model-value'
     },
     props: {
         modelValue: { type: String, required: true }

--- a/src/components/compound/DlTable/DlTable.vue
+++ b/src/components/compound/DlTable/DlTable.vue
@@ -1263,7 +1263,7 @@ export default defineComponent({
                 ...computedPagination.value,
                 'update:rowsPerPage': (rowsPerPage: number) =>
                     setPagination({ rowsPerPage }),
-                'update:modelValue': (page: number) => setPagination({ page }),
+                'update:model-value': (page: number) => setPagination({ page }),
                 modelValue: computedPagination.value.page,
                 totalItems: computedRowsNumber.value
             }

--- a/src/components/compound/DlTable/DlTable.vue
+++ b/src/components/compound/DlTable/DlTable.vue
@@ -478,7 +478,7 @@
                             @update:rowsPerPage="
                                 (v) => setPagination({ rowsPerPage: v })
                             "
-                            @update:modelValue="
+                            @update:model-value="
                                 (v) => setPagination({ page: v })
                             "
                         />

--- a/src/components/compound/DlTabs/DlTabs.vue
+++ b/src/components/compound/DlTabs/DlTabs.vue
@@ -59,7 +59,7 @@ export default defineComponent({
         DlTab
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlThumbnailGallery/DlThumbnailGallery.vue
+++ b/src/components/compound/DlThumbnailGallery/DlThumbnailGallery.vue
@@ -73,7 +73,7 @@ export default defineComponent({
         DlTooltip
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlThumbnailGallery/DlThumbnailGallery.vue
+++ b/src/components/compound/DlThumbnailGallery/DlThumbnailGallery.vue
@@ -74,7 +74,7 @@ export default defineComponent({
     },
     model: {
         prop: 'modelValue',
-        event: 'update:modelValue'
+        event: 'update:model-value'
     },
     props: {
         /**
@@ -120,7 +120,7 @@ export default defineComponent({
             default: 0.3
         }
     },
-    emits: ['update:modelValue', 'selected'],
+    emits: ['update:model-value', 'selected'],
     data() {
         return {
             currentList: { first: 0, last: this.visibleThumbnails }
@@ -186,7 +186,7 @@ export default defineComponent({
                 : 'slider__arrow--icon--invisible'
         },
         handleThumbnailMousedown(image: string) {
-            this.$emit('update:modelValue', image)
+            this.$emit('update:model-value', image)
             this.$emit('selected', image)
         }
     }

--- a/src/components/compound/DlToggleButton/DlToggleButton.vue
+++ b/src/components/compound/DlToggleButton/DlToggleButton.vue
@@ -60,7 +60,7 @@ export default defineComponent({
             required: true
         }
     },
-    emits: ['update:modelValue', 'change'],
+    emits: ['update:model-value', 'change'],
     data: () => ({
         scopedValue: null as string | number,
         hoverButton: null as string | number
@@ -79,7 +79,7 @@ export default defineComponent({
                     buttonValue = null
                 }
                 this.scopedValue = buttonValue
-                this.$emit('update:modelValue', buttonValue)
+                this.$emit('update:model-value', buttonValue)
             }
         },
         toggleButtons(): DlToggleButtonOption[] {

--- a/src/components/compound/DlToggleButton/DlToggleButton.vue
+++ b/src/components/compound/DlToggleButton/DlToggleButton.vue
@@ -43,7 +43,7 @@ export default defineComponent({
     name: 'DlToggleButton',
     components: { DlButton },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/compound/DlTreeTable/DlTreeTable.vue
+++ b/src/components/compound/DlTreeTable/DlTreeTable.vue
@@ -512,7 +512,7 @@
                             @update:rowsPerPage="
                                 (v) => setPagination({ rowsPerPage: v })
                             "
-                            @update:modelValue="
+                            @update:model-value="
                                 (v) => setPagination({ page: v })
                             "
                         />

--- a/src/components/compound/DlTreeTable/DlTreeTable.vue
+++ b/src/components/compound/DlTreeTable/DlTreeTable.vue
@@ -1215,7 +1215,7 @@ export default defineComponent({
                 ...computedPagination.value,
                 'update:rowsPerPage': (rowsPerPage: number) =>
                     setPagination({ rowsPerPage }),
-                'update:modelValue': (page: number) => setPagination({ page }),
+                'update:model-value': (page: number) => setPagination({ page }),
                 modelValue: computedPagination.value.page,
                 totalItems: computedRowsNumber.value
             }

--- a/src/components/essential/DlCheckbox/DlCheckbox.vue
+++ b/src/components/essential/DlCheckbox/DlCheckbox.vue
@@ -89,7 +89,7 @@ const ValueTypes = [Array, Boolean, String, Number, Object, Function]
 export default defineComponent({
     name: 'DlCheckbox',
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/essential/DlMenu/DlMenu.vue
+++ b/src/components/essential/DlMenu/DlMenu.vue
@@ -91,7 +91,7 @@ export default defineComponent({
     },
     inheritAttrs: false,
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/essential/DlRadio/DlRadio.vue
+++ b/src/components/essential/DlRadio/DlRadio.vue
@@ -68,7 +68,7 @@ import { v4 } from 'uuid'
 export default defineComponent({
     name: 'DlRadio',
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/essential/DlSwitch/DlSwitch.vue
+++ b/src/components/essential/DlSwitch/DlSwitch.vue
@@ -64,7 +64,7 @@ const Any = [Array, Boolean, String, Number, Object]
 export default defineComponent({
     name: 'DlSwitch',
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/components/essential/DlTextArea/DlTextArea.vue
+++ b/src/components/essential/DlTextArea/DlTextArea.vue
@@ -126,7 +126,7 @@ export default defineComponent({
         DlInfoErrorMessage
     },
     model: {
-        prop: 'modelValue',
+        prop: 'model-value',
         event: 'update:model-value'
     },
     props: {

--- a/src/hooks/use-anchor.ts
+++ b/src/hooks/use-anchor.ts
@@ -219,7 +219,7 @@ export default function useAnchor({
         pickAnchorEl()
 
         if (props.modelValue === true && anchorEl.value === null) {
-            emit('update:modelValue', false)
+            emit('update:model-value', false)
         }
     })
 

--- a/src/hooks/use-model-toggle.ts
+++ b/src/hooks/use-model-toggle.ts
@@ -4,10 +4,11 @@ import {
     onMounted,
     getCurrentInstance,
     Ref,
-    PropType
+    PropType,
+    isVue2
 } from 'vue-demi'
 
-const modelValueNaming = 'model-value'
+const modelValueNaming = isVue2 ? 'model-value' : 'modelValue'
 
 const staticUseModelToggleProps: any = {
     modelValue: {

--- a/src/hooks/use-model-toggle.ts
+++ b/src/hooks/use-model-toggle.ts
@@ -4,11 +4,10 @@ import {
     onMounted,
     getCurrentInstance,
     Ref,
-    PropType,
-    isVue2
+    PropType
 } from 'vue-demi'
 
-const modelValueNaming = isVue2 ? 'model-value' : 'modelValue'
+const modelValueNaming = 'model-value'
 
 const staticUseModelToggleProps: any = {
     modelValue: {

--- a/src/stories/DlDateTimeRange.stories.js
+++ b/src/stories/DlDateTimeRange.stories.js
@@ -7,7 +7,7 @@ export default {
     component: DlDateTimeRange,
     argTypes: {
         modelValue: {
-            name: 'modelValue',
+            name: 'model-value',
             defaultValue: null,
             control: 'object',
             description: 'A DateInterval object',
@@ -192,7 +192,7 @@ const Template = (args) => {
                 v-bind="args"
                 :available-range="availableRange"
                 @set-type="handleSetType"
-                @update:modelValue="updateModelValue"
+                @update:model-value="updateModelValue"
             />
         </div>
     </div>

--- a/src/stories/DlSwitch.stories.js
+++ b/src/stories/DlSwitch.stories.js
@@ -182,7 +182,7 @@ const Template = (args) => ({
     template: `
     <div style="padding: 50px">
         <div style="display: flex; flex-direction: column; gap: 1rem">
-            <dl-switch v-model="value" @update:modelValue="change" right-label="active switch" v-bind="args" />
+            <dl-switch v-model="value" @update:model-value="change" right-label="active switch" v-bind="args" />
             <dl-switch right-label="inactive switch" v-bind="args" disabled />
         </div>
     </div>

--- a/tests/DlDateTimeRange/DlCalendar.spec.ts
+++ b/tests/DlDateTimeRange/DlCalendar.spec.ts
@@ -78,7 +78,7 @@ describe('DlCalendar', () => {
                 wrapper.vm.handleClick(customDate)
             })
             it('should the right model value data', function () {
-                expect(wrapper.emitted()['update:modelValue']).toEqual([
+                expect(wrapper.emitted()['update:model-value']).toEqual([
                     [
                         {
                             from: date,

--- a/tests/DlDateTimeRange/DlDatePicker.spec.ts
+++ b/tests/DlDateTimeRange/DlDatePicker.spec.ts
@@ -29,7 +29,7 @@ describe('DlDatePicker', () => {
         it('should update the model value', () => {
             const dateInterval = { from: date, to: date2 }
             wrapper.vm.updateModelValue(dateInterval)
-            expect(wrapper.emitted('update:modelValue')).toEqual([
+            expect(wrapper.emitted('update:model-value')).toEqual([
                 [dateInterval]
             ])
         })
@@ -72,7 +72,7 @@ describe('DlDatePicker', () => {
 
         it('should emit the currently selected state on mouseup', () => {
             wrapper.vm.handleMouseup()
-            expect(wrapper.emitted()['update:modelValue']).toEqual([
+            expect(wrapper.emitted()['update:model-value']).toEqual([
                 [
                     {
                         from: date,

--- a/tests/DlDateTimeRange/DlDateTimeRange.spec.ts
+++ b/tests/DlDateTimeRange/DlDateTimeRange.spec.ts
@@ -39,7 +39,7 @@ describe('Date Time Range', () => {
         it('should select the current day', () => {
             const today = wrapper.vm.sidebarDayOptions[0] as DayTypeOption
             wrapper.vm.handleDayTypeOptionClick(today)
-            expect(wrapper.emitted()['update:modelValue'][0]).toEqual([
+            expect(wrapper.emitted()['update:model-value'][0]).toEqual([
                 { from: today.value?.from, to: today.value?.to }
             ])
         })
@@ -48,7 +48,7 @@ describe('Date Time Range', () => {
                 wrapper.vm.sidebarDayOptions.length - 1
             ] as DayTypeOption
             wrapper.vm.handleDayTypeOptionClick(customByMonth)
-            expect(wrapper.emitted()['update:modelValue'][0]).toEqual([
+            expect(wrapper.emitted()['update:model-value'][0]).toEqual([
                 { from: customByMonth.value?.from, to: customByMonth.value?.to }
             ])
             expect(wrapper.emitted()['set-type']).toEqual([['month']])
@@ -56,35 +56,35 @@ describe('Date Time Range', () => {
         it('should select the previous day', () => {
             const yesterday = wrapper.vm.sidebarDayOptions[1] as DayTypeOption
             wrapper.vm.handleDayTypeOptionClick(yesterday)
-            expect(wrapper.emitted()['update:modelValue'][0]).toEqual([
+            expect(wrapper.emitted()['update:model-value'][0]).toEqual([
                 { from: yesterday.value?.from, to: yesterday.value?.to }
             ])
         })
         it('should select the previous day', () => {
             const yesterday = wrapper.vm.sidebarDayOptions[1] as DayTypeOption
             wrapper.vm.handleDayTypeOptionClick(yesterday)
-            expect(wrapper.emitted()['update:modelValue'][0]).toEqual([
+            expect(wrapper.emitted()['update:model-value'][0]).toEqual([
                 { from: yesterday.value?.from, to: yesterday.value?.to }
             ])
         })
         it('should select the last 7 days', () => {
             const oneWeekAgo = wrapper.vm.sidebarDayOptions[2] as DayTypeOption
             wrapper.vm.handleDayTypeOptionClick(oneWeekAgo)
-            expect(wrapper.emitted()['update:modelValue'][0]).toEqual([
+            expect(wrapper.emitted()['update:model-value'][0]).toEqual([
                 { from: oneWeekAgo.value?.from, to: oneWeekAgo.value?.to }
             ])
         })
         it('should select the last 14 days', () => {
             const twoWeeksAgo = wrapper.vm.sidebarDayOptions[3] as DayTypeOption
             wrapper.vm.handleDayTypeOptionClick(twoWeeksAgo)
-            expect(wrapper.emitted()['update:modelValue'][0]).toEqual([
+            expect(wrapper.emitted()['update:model-value'][0]).toEqual([
                 { from: twoWeeksAgo.value?.from, to: twoWeeksAgo.value?.to }
             ])
         })
         it('should select the last 30 days', () => {
             const oneMonthAgo = wrapper.vm.sidebarDayOptions[4] as DayTypeOption
             wrapper.vm.handleDayTypeOptionClick(oneMonthAgo)
-            expect(wrapper.emitted()['update:modelValue'][0]).toEqual([
+            expect(wrapper.emitted()['update:model-value'][0]).toEqual([
                 { from: oneMonthAgo.value?.from, to: oneMonthAgo.value?.to }
             ])
         })
@@ -92,7 +92,7 @@ describe('Date Time Range', () => {
             const thisMonth = wrapper.vm
                 .sidebarMonthOptions[0] as MonthTypeOption
             wrapper.vm.handleMonthTypeOptionClick(thisMonth)
-            expect(wrapper.emitted()['update:modelValue'][0]).toEqual([
+            expect(wrapper.emitted()['update:model-value'][0]).toEqual([
                 { from: thisMonth.value?.from, to: thisMonth.value?.to }
             ])
         })
@@ -101,7 +101,7 @@ describe('Date Time Range', () => {
             const lastMonth = wrapper.vm
                 .sidebarMonthOptions[1] as MonthTypeOption
             wrapper.vm.handleMonthTypeOptionClick(lastMonth)
-            expect(wrapper.emitted()['update:modelValue'][0]).toEqual([
+            expect(wrapper.emitted()['update:model-value'][0]).toEqual([
                 { from: lastMonth.value?.from, to: lastMonth.value?.to }
             ])
         })
@@ -110,7 +110,7 @@ describe('Date Time Range', () => {
             const last3Months = wrapper.vm
                 .sidebarMonthOptions[2] as MonthTypeOption
             wrapper.vm.handleMonthTypeOptionClick(last3Months)
-            expect(wrapper.emitted()['update:modelValue'][0]).toEqual([
+            expect(wrapper.emitted()['update:model-value'][0]).toEqual([
                 { from: last3Months.value?.from, to: last3Months.value?.to }
             ])
         })
@@ -119,7 +119,7 @@ describe('Date Time Range', () => {
             const last6Months = wrapper.vm
                 .sidebarMonthOptions[3] as MonthTypeOption
             wrapper.vm.handleMonthTypeOptionClick(last6Months)
-            expect(wrapper.emitted()['update:modelValue'][0]).toEqual([
+            expect(wrapper.emitted()['update:model-value'][0]).toEqual([
                 { from: last6Months.value?.from, to: last6Months.value?.to }
             ])
         })
@@ -128,7 +128,7 @@ describe('Date Time Range', () => {
             const lastYear = wrapper.vm
                 .sidebarMonthOptions[4] as MonthTypeOption
             wrapper.vm.handleMonthTypeOptionClick(lastYear)
-            expect(wrapper.emitted()['update:modelValue'][0]).toEqual([
+            expect(wrapper.emitted()['update:model-value'][0]).toEqual([
                 { from: lastYear.value?.from, to: lastYear.value?.to }
             ])
         })
@@ -151,7 +151,7 @@ describe('Date Time Range', () => {
         })
 
         it('should have the right date', () => {
-            expect(wrapper.emitted()['update:modelValue'][0]).toEqual([
+            expect(wrapper.emitted()['update:model-value'][0]).toEqual([
                 {
                     from: new CustomDate(date1).startOf('month').toDate(),
                     to: new CustomDate(date1).startOf('month').toDate()
@@ -179,7 +179,7 @@ describe('Date Time Range', () => {
         })
 
         it('should have the right date', () => {
-            expect(wrapper.emitted()['update:modelValue'][0]).toEqual([
+            expect(wrapper.emitted()['update:model-value'][0]).toEqual([
                 {
                     from: new CustomDate(date1).startOf('day').toDate(),
                     to: new CustomDate(date1).startOf('day').toDate()

--- a/tests/DlDateTimeRange/DlMonthCalendar.spec.ts
+++ b/tests/DlDateTimeRange/DlMonthCalendar.spec.ts
@@ -29,7 +29,7 @@ describe('DlMonthCalendar', () => {
         })
         it('should emit date on click', () => {
             wrapper.vm.handleClick(0)
-            expect(wrapper.emitted()['update:modelValue']).toEqual([
+            expect(wrapper.emitted()['update:model-value']).toEqual([
                 [
                     {
                         from: date,

--- a/tests/DlDateTimeRange/DlTimePicker.spec.ts
+++ b/tests/DlDateTimeRange/DlTimePicker.spec.ts
@@ -35,13 +35,13 @@ describe('Time picker', () => {
 
         it('should have the right model value', function () {
             wrapper.vm.handleFromTimeChange(from)
-            expect(wrapper.emitted()['update:modelValue'][0]).toEqual([
+            expect(wrapper.emitted()['update:model-value'][0]).toEqual([
                 { from: date, to: date2 }
             ])
         })
         it('should have the right model value', function () {
             wrapper.vm.handleToTimeChange(to)
-            expect(wrapper.emitted()['update:modelValue'][1]).toEqual([
+            expect(wrapper.emitted()['update:model-value'][1]).toEqual([
                 { from: date, to: date2 }
             ])
         })

--- a/tests/DlPagination/PageNavigation.spec.ts
+++ b/tests/DlPagination/PageNavigation.spec.ts
@@ -37,7 +37,7 @@ describe('PageNavigation', () => {
                 await btns[0].trigger('click')
             })
             it('should emitted click event', function () {
-                expect(wrapper.emitted()['update:modelValue'][0]).toBeTruthy()
+                expect(wrapper.emitted()['update:model-value'][0]).toBeTruthy()
             })
             it('should have the right value', function () {
                 expect(wrapper.vm.value).toBe(1)

--- a/tests/DlPagination/PaginationQuickNav.spec.ts
+++ b/tests/DlPagination/PaginationQuickNav.spec.ts
@@ -32,7 +32,7 @@ describe('QuickNavigation', () => {
                 input.trigger('keyup', { key: 'Enter' })
             })
             it('should emitted modelValue', function () {
-                expect(wrapper.emitted()['update:modelValue'][0]).toBeTruthy()
+                expect(wrapper.emitted()['update:model-value'][0]).toBeTruthy()
             })
         })
         describe('When handle values bigger than MAX and smaller than MIN', () => {
@@ -40,14 +40,14 @@ describe('QuickNavigation', () => {
                 wrapper.vm.inputValue = '999'
                 wrapper.vm.handleNavigation()
                 expect(
-                    (wrapper.emitted()['update:modelValue'][1] as any[])[0]
+                    (wrapper.emitted()['update:model-value'][1] as any[])[0]
                 ).toBe(MAX)
             })
             it('should have the MIN modelValue', function () {
                 wrapper.vm.inputValue = '-10'
                 wrapper.vm.handleNavigation()
                 expect(
-                    (wrapper.emitted()['update:modelValue'][2] as any[])[0]
+                    (wrapper.emitted()['update:model-value'][2] as any[])[0]
                 ).toBe(MIN)
             })
         })

--- a/tests/DlPagination/RowsSelector.spec.ts
+++ b/tests/DlPagination/RowsSelector.spec.ts
@@ -28,7 +28,7 @@ describe('RowsSelector', () => {
             })
 
             it('should emitted modelValue event', function () {
-                expect(wrapper.emitted()['update:modelValue'][0]).toBeTruthy()
+                expect(wrapper.emitted()['update:model-value'][0]).toBeTruthy()
             })
         })
     })

--- a/tests/DlSmartSearch/DlSmartSearchInput.spec.ts
+++ b/tests/DlSmartSearch/DlSmartSearchInput.spec.ts
@@ -139,7 +139,7 @@ describe('DlSmartSearchInput', () => {
             }
         })
         wrapper.vm.clearValue()
-        expect(wrapper.emitted()['update:modelValue']).toEqual([['']])
+        expect(wrapper.emitted()['update:model-value']).toEqual([['']])
     })
 
     it('should handle keyboard input', () => {
@@ -164,7 +164,7 @@ describe('DlSmartSearchInput', () => {
         wrapper.vm.handleValueChange({
             target: { textContent: 'text' }
         } as any as Event)
-        expect(wrapper.emitted()['update:modelValue']).toEqual([['text']])
+        expect(wrapper.emitted()['update:model-value']).toEqual([['text']])
     })
 
     it('should handle screen button click', () => {


### PR DESCRIPTION
@SorinOpt @prodan-eric please  take a look at this PR.
this is in response to what @prodan-eric and i talked about how events should be always model-value and  not modelValue as it causes conflict between vue3 and vue2
Vue3 can handle the model-value but vue2 cant handle modelValue.
i believe that in vue3 the fact we pass model and explicitly state the event for it helps us always have same event working on both platforms 

I hope that it didnt break any logic as i dont fully remember when we coded the hooks if it can do that. @SorinOpt please validate that part.