### PR TITLE
bug/DLCL-516-dldropdownbutton-when-passing-color-secondary-the-arrow-is-missing

### DIFF
--- a/src/components/basic/DlButton/DlButton.vue
+++ b/src/components/basic/DlButton/DlButton.vue
@@ -27,7 +27,7 @@
                     v-if="hasIcon"
                     class="dl-button-icon"
                     :size="iconSizePX"
-                    :color="iconColor || textColor"
+                    :color="getIconColor"
                     :icon="icon"
                     :style="cssButtonVars"
                 />
@@ -194,6 +194,17 @@ export default defineComponent({
         }
     },
     computed: {
+        getIconColor(): string {
+            if (this.iconColor) {
+                return this.iconColor
+            }
+
+            if (this.textColor) {
+                return this.textColor
+            }
+
+            return 'dl-color-secondary'
+        },
         capitalizeFirst(): string {
             if (this.transform === 'default') {
                 return 'first-letter-capitalized'

--- a/src/components/compound/DlDropdownButton/DlDropdownButton.vue
+++ b/src/components/compound/DlDropdownButton/DlDropdownButton.vue
@@ -69,13 +69,7 @@
                 :class="iconClass"
                 :icon="dropdownIcon"
                 :size="iconSize"
-                :color="
-                    disabled
-                        ? 'dl-color-disabled'
-                        : outlined && !textColor
-                            ? 'dl-color-secondary'
-                            : textColor || 'dl-color-white'
-                "
+                :color="getIconColor"
             />
         </dl-button>
         <dl-menu
@@ -134,13 +128,7 @@
                 :class="iconClass"
                 :icon="dropdownIcon"
                 :size="iconSize"
-                :color="
-                    disabled
-                        ? 'dl-color-disabled'
-                        : outlined && !textColor
-                            ? 'dl-color-secondary'
-                            : textColor || 'dl-color-white'
-                "
+                :color="getIconColor"
             />
         </div>
 
@@ -404,6 +392,26 @@ export default defineComponent({
             )
         })
 
+        const getIconColor = computed(() => {
+            if (props.disabled) {
+                return 'dl-color-disabled'
+            }
+
+            if (props.textColor) {
+                return props.textColor
+            }
+
+            if (props.outlined) {
+                return 'dl-color-secondary'
+            }
+
+            if (props.color) {
+                return props.color
+            }
+
+            return 'dl-color-medium'
+        })
+
         return {
             uuid: `dl-dropdown-button-${v4()}`,
             identifierClass,
@@ -425,7 +433,8 @@ export default defineComponent({
             props,
             setHighlightedIndex,
             handleSelectedItem,
-            cssVars
+            cssVars,
+            getIconColor
         }
     }
 })

--- a/src/demos/DlDropdownButtonDemo.vue
+++ b/src/demos/DlDropdownButtonDemo.vue
@@ -1,6 +1,31 @@
 <template>
     <div>
         <div style="display: flex; gap: 20px; flex-direction: column">
+            <h2>without text-color prop</h2>
+            <dl-dropdown-button
+                v-model="showing"
+                flat
+                :label="outlinedLabel"
+                :no-wrap="false"
+                :overflow="false"
+                auto-close
+                fit-content
+                icon="icon-dl-sdk-documentation"
+                :color="'secondary'"
+                size="s"
+            >
+                <dl-list>
+                    <dl-list-item
+                        v-for="val in ['Photos', 'Videos', 'Articles']"
+                        :key="val"
+                        clickable
+                        @click="handleOutlinedSelect(val)"
+                    >
+                        <dl-item-section> {{ val }} </dl-item-section>
+                    </dl-list-item>
+                </dl-list>
+            </dl-dropdown-button>
+
             <h2>Splitted</h2>
             <dl-dropdown-button
                 auto-close


### PR DESCRIPTION
---------------------------------------------
| Q  | A |
| ------------- | ------------- |
| Related tickets | https://github.com/dataloop-ai/components/issues/516 |
| Api Doc |  N |
| Vue2 |  Y |
| Vue3 |  Y |
| Storybook |  N |
| Tests |  N |
| Demo |  Y |





### Changelog


* Update: The dropdown icon styles has updated

------------------------