### PR TITLE
add more watchers to isOverflowing, check only width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dataloop-ai/components",
-  "version": "0.18.96",
+  "version": "0.18.97",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dataloop-ai/components",
-      "version": "0.18.96",
+      "version": "0.18.97",
       "license": "Apache-2.0",
       "dependencies": {
         "@dataloop-ai/icons": "^3.0.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4373,8 +4373,9 @@
     },
     "node_modules/@types/resize-observer-browser": {
       "version": "0.1.7",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.7.tgz",
+      "integrity": "sha512-G9eN0Sn0ii9PWQ3Vl72jDPgeJwRWhv2Qk/nQkJuWmRmOB4HX3/BhD5SE1dZs/hzPZL/WKnvF0RHdTSG54QJFyg==",
+      "dev": true
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.3",
@@ -17970,6 +17971,8 @@
     },
     "@types/resize-observer-browser": {
       "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.7.tgz",
+      "integrity": "sha512-G9eN0Sn0ii9PWQ3Vl72jDPgeJwRWhv2Qk/nQkJuWmRmOB4HX3/BhD5SE1dZs/hzPZL/WKnvF0RHdTSG54QJFyg==",
       "dev": true
     },
     "@types/scheduler": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dataloop-ai/components",
-  "version": "0.18.96",
+  "version": "0.18.97",
   "exports": {
     ".": "./index.ts",
     "./models": "./models.ts",

--- a/src/components/basic/DlChip/DlChip.vue
+++ b/src/components/basic/DlChip/DlChip.vue
@@ -27,7 +27,7 @@
         >
             <div
                 ref="dlChipRef"
-                class="dl-chip--ellipsis"
+                :class="{ 'dl-chip--ellipsis': overflow }"
             >
                 <slot>
                     {{ hasLabel ? label : null }}
@@ -49,7 +49,7 @@
 </template>
 
 <script lang="ts">
-import { PropType, defineComponent, ref } from 'vue-demi'
+import { PropType, defineComponent, ref, watch } from 'vue-demi'
 import { DlTooltip } from '../../shared'
 import { DlIcon } from '../../essential'
 import { useSizeObserver } from '../../../hooks/use-size-observer'
@@ -92,11 +92,16 @@ export default defineComponent({
         overflow: { type: Boolean, default: false },
         fit: { type: Boolean, default: false }
     },
-    emits: ['remove'],
-    setup() {
+    emits: ['remove', 'ellipsis'],
+    setup(props, ctx) {
         const isVisible = ref(true)
         const dlChipRef = ref(null)
-        const { hasEllipsis } = useSizeObserver(dlChipRef)
+        const label = ref(props.label)
+        const { hasEllipsis } = useSizeObserver(dlChipRef, label)
+
+        watch(hasEllipsis, () => {
+            ctx.emit('ellipsis', hasEllipsis.value)
+        })
 
         return {
             isVisible,

--- a/src/hooks/use-size-observer.ts
+++ b/src/hooks/use-size-observer.ts
@@ -1,22 +1,36 @@
-import { onBeforeUnmount, onMounted, ref, Ref } from 'vue-demi'
+import { onBeforeUnmount, onMounted, ref, Ref, watch } from 'vue-demi'
 import { isEllipsisActive } from '../utils/is-ellipsis-active'
 import { get } from 'lodash'
 
-export function useSizeObserver(elRef: Ref, entryLevel = 'target') {
+export function useSizeObserver(elRef: Ref, ...refsToWatch: any[]) {
+    const entryLevel = 'target'
     const widthRef = ref(0)
     const heightRef = ref(0)
     const hasEllipsis = ref(false)
     const borderBoxSize = ref(null)
-    const resizeObserver = new ResizeObserver((entries) => {
-        for (const entry of entries) {
-            hasEllipsis.value = isEllipsisActive(get(entry, entryLevel))
-            widthRef.value = entry.contentRect.width
-            heightRef.value = entry.contentRect.height
-            borderBoxSize.value = entry.borderBoxSize
+    const calcEllipsis = (el: HTMLElement) => {
+        hasEllipsis.value = isEllipsisActive(el)
+    }
+    const resizeObserver = new ResizeObserver(
+        (entries: ResizeObserverEntry[]) => {
+            for (const entry of entries) {
+                hasEllipsis.value = isEllipsisActive(get(entry, entryLevel))
+                widthRef.value = entry.contentRect.width
+                heightRef.value = entry.contentRect.height
+                borderBoxSize.value = entry.borderBoxSize
+            }
         }
-    })
+    )
 
     onMounted(() => elRef.value && resizeObserver.observe(elRef.value))
+    watch(elRef, () => {
+        elRef.value && calcEllipsis(elRef.value)
+    })
+    for (const ref of refsToWatch) {
+        watch(ref, () => {
+            elRef.value && calcEllipsis(elRef.value)
+        })
+    }
     onBeforeUnmount(() => elRef.value && resizeObserver.unobserve(elRef.value))
 
     return {

--- a/src/utils/is-ellipsis-active.ts
+++ b/src/utils/is-ellipsis-active.ts
@@ -1,6 +1,3 @@
 export const isEllipsisActive = (e: Element) => {
-    return (
-        (e as HTMLElement).offsetWidth < e.scrollWidth ||
-        (e as HTMLElement).offsetHeight < e.scrollHeight
-    )
+    return (e as HTMLElement).offsetWidth < e.scrollWidth
 }

--- a/tests/DlChip.spec.ts
+++ b/tests/DlChip.spec.ts
@@ -91,7 +91,7 @@ describe('DlChip', () => {
                 }
             })
 
-            chip = await wrapper.find(`#${wrapper.vm.uuid}`)
+            chip = wrapper.find(`#${wrapper.vm.uuid}`)
         })
 
         it('will have max-width of "fit-content"', () => {
@@ -119,7 +119,7 @@ describe('DlChip', () => {
                     }
                 })
 
-                chip = await wrapper.find(`#${wrapper.vm.uuid}`)
+                chip = wrapper.find(`#${wrapper.vm.uuid}`)
             })
 
             it('will have the inputted transform', () => {
@@ -146,7 +146,7 @@ describe('DlChip', () => {
                     }
                 })
 
-                chip = await wrapper.find(`#${wrapper.vm.uuid}`)
+                chip = wrapper.find(`#${wrapper.vm.uuid}`)
             })
 
             it('will have the inputted transform', () => {


### PR DESCRIPTION
**Thank you for your contribution to the repo. Before submitting this PR, please make sure:**
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests - _Impossible without excessive mocks_
- [ ] You have updated documentation
- [x] You have tested your changes

The `isOverflowing` indicator on DlChip was always returning true.

- Aletered the `isEllipsisActive` function to take only the width into account
- Added more watches for relevant changes
- Added an even for ellipsis state change on DlChip

**Please indicate if this PR contains:**
- [x] A bug fix
- [ ] A feature request
- [ ] Breaking changes
- [x] An enhancement
