### PR TITLE
Passed fullWidth to tabs-wrapper in dl0tabs

### DIFF
--- a/src/components/compound/DlTabs/DlTabs.vue
+++ b/src/components/compound/DlTabs/DlTabs.vue
@@ -9,7 +9,7 @@
             :is-scrollable="isOverflowing"
             :is-at-end="isAtEnd"
             :is-at-start="isAtStart"
-            class="dl-tabs-root"
+            :class="{ 'full-width': fullWidth, 'dl-tabs-root': true }"
             :is-vertical="vertical"
             @left-arrow-click="handleLeft"
             @right-arrow-click="handleRight"


### PR DESCRIPTION
When using fullWidth in dlTabs the class needs to be passed to tabsWrapper in order to fully function.

**Thank you for your contribution to the repo. Before submitting this PR, please make sure:**
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests
- [ ] You have updated documentation
- [x] You have tested your changes

**Please provide a description of the changes proposed in the pull request and reference any related issues in the repository.**

**Please indicate if this PR contains:**
- [x] A bug fix
- [ ] A feature request
- [ ] Breaking changes
- [ ] An enhancement
