### PR TITLE
put quotes around strings in suggestions

### DIFF
--- a/src/components/compound/DlSearches/DlSmartSearch/components/DlSmartSearchInput.vue
+++ b/src/components/compound/DlSearches/DlSmartSearch/components/DlSmartSearchInput.vue
@@ -335,7 +335,8 @@ export default defineComponent({
             }
         }
 
-        const setInputFromSuggestion = (value: string) => {
+        const setInputFromSuggestion = (suggestion: any) => {
+            const value = '' + suggestion
             let stringValue = ''
             let caretPosition = 0
             if (searchQuery.value.length) {

--- a/src/components/compound/DlSearches/DlSmartSearch/components/SuggestionsDropdown.vue
+++ b/src/components/compound/DlSearches/DlSmartSearch/components/SuggestionsDropdown.vue
@@ -28,7 +28,7 @@
                     :highlighted="suggestionIndex === highlightedIndex"
                     @click="handleOption(item)"
                 >
-                    {{ item }}
+                    {{ removeQuotes(item) }}
                 </dl-list-item>
             </dl-list>
         </dl-menu>
@@ -115,11 +115,18 @@ export default defineComponent({
             emit('update:model-value', false)
         }
 
+        const removeQuotes = (item: any) => {
+            const str = '' + item
+            const match = str.match(/^'(.*)'$/)
+            return match ? match[1] : str
+        }
+
         return {
             defaultTarget,
             setHighlightedIndex,
             handleSelectedItem,
             highlightedIndex,
+            removeQuotes,
             onShow,
             onHide,
             emitModelValue,

--- a/src/demos/SmartSearchDemo/DlSmartSearchDemo.vue
+++ b/src/demos/SmartSearchDemo/DlSmartSearchDemo.vue
@@ -136,6 +136,7 @@ export default defineComponent({
                 '*': 'any'
             },
             type: ['dir', 'file'],
+            test0: ['why wont', 'this work', 123],
             test1: ['5', '6', 'number'],
             test2: ['true', 'false']
         }

--- a/src/hooks/use-suggestions.ts
+++ b/src/hooks/use-suggestions.ts
@@ -248,11 +248,15 @@ export const useSuggestions = (
             }
 
             if (Array.isArray(dataType)) {
-                localSuggestions = dataType.filter(
-                    (type) =>
-                        typeof type === 'string' &&
-                        !knownDataTypes.includes(type)
-                ) as string[]
+                localSuggestions = dataType
+                    .filter(
+                        (type) =>
+                            !knownDataTypes.includes(type as string) &&
+                            typeof type !== 'object'
+                    )
+                    .map((type) =>
+                        typeof type === 'string' ? `'${type}'` : type
+                    ) as string[]
 
                 if (!value) continue
 
@@ -696,7 +700,7 @@ const getValueSuggestions = (
                 !knownDataTypes.includes(type as string) &&
                 typeof type !== 'object'
             ) {
-                suggestion.push(type)
+                suggestion.push(typeof type === 'string' ? `'${type}'` : type)
             }
         }
     }

--- a/tests/DlSmartSearch/DlSmartSearchInput.spec.ts
+++ b/tests/DlSmartSearch/DlSmartSearchInput.spec.ts
@@ -348,7 +348,7 @@ describe('DlSmartSearchInput', () => {
                 const resultString1 = `completed = low AND metadata.test = 'ok'`
                 const resultString2 = `level != = low AND metadata.test = 'ok'`
                 const resultString3 = `level = low OR AND metadata.test = 'ok'`
-                const resultString4 = `level = high low AND metadata.test = 'ok'`
+                const resultString4 = `level = 'high' low AND metadata.test = 'ok'`
                 const resultString5 = `level = low AND metadata.nesting test = 'ok'`
                 beforeAll(async () => {
                     wrapper.vm.focused = true

--- a/tests/hooks/use-suggestions.spec.ts
+++ b/tests/hooks/use-suggestions.spec.ts
@@ -132,12 +132,17 @@ describe('use-suggestions', () => {
     describe('when the field has values defined', () => {
         it('suggestions should match the field values', () => {
             findSuggestions('Level = ')
-            expect(suggestions.value).toEqual(['high', 'medium', 'low', 30])
+            expect(suggestions.value).toEqual([
+                `'high'`,
+                `'medium'`,
+                `'low'`,
+                30
+            ])
         })
 
         it('suggestions should match the correct field value without the quotes', () => {
             findSuggestions('Level = me')
-            expect(suggestions.value).toEqual(['medium'])
+            expect(suggestions.value).toEqual([`'medium'`])
         })
 
         it('suggestions should be empty when none of the field values were matched', () => {


### PR DESCRIPTION
this would always put quotes around strings in suggestions, while leaving out non-string things:
<img width="171" alt="Screen Shot 2023-11-29 at 11 23 20 AM" src="https://github.com/dataloop-ai/components/assets/146977958/32f300af-e887-48ec-ad4d-0bd9f4f67971">
<img width="197" alt="Screen Shot 2023-11-29 at 11 23 31 AM" src="https://github.com/dataloop-ai/components/assets/146977958/d58095d9-39b8-41ec-b89a-b0aba121b450">
<img width="134" alt="Screen Shot 2023-11-29 at 11 23 39 AM" src="https://github.com/dataloop-ai/components/assets/146977958/11a1346a-b0eb-4de6-b51b-ba0c59a83197">

related issues:
https://dataloop.atlassian.net/browse/DAT-56547
https://dataloop.atlassian.net/browse/DAT-56126

previously the quotes were only added when converting back from model