### PR TITLE
DAT-57603: wrap value aliases in quotes

### DIFF
--- a/src/demos/SmartSearchDemo/DlSmartSearchDemo.vue
+++ b/src/demos/SmartSearchDemo/DlSmartSearchDemo.vue
@@ -157,6 +157,12 @@ export default defineComponent({
                     }
                 ]
             },
+            only_va: [
+                {
+                    'String Value': '12345',
+                    'Numeric Value': 12345
+                }
+            ],
             type: [
                 'class',
                 'point',

--- a/src/hooks/use-suggestions.ts
+++ b/src/hooks/use-suggestions.ts
@@ -741,7 +741,7 @@ const getValueSuggestions = (
             default:
                 if (typeof type === 'object') {
                     // value aliases: key is the alias, value is the actual value
-                    for (const key in type) suggestion.push(key)
+                    for (const key in type) suggestion.push(`'${key}'`)
                 }
                 break
         }

--- a/tests/hooks/use-suggestions.spec.ts
+++ b/tests/hooks/use-suggestions.spec.ts
@@ -164,7 +164,7 @@ describe('use-suggestions', () => {
     describe('when the field has value aliases defined', () => {
         it('suggestions should have value aliases', () => {
             findSuggestions('name = ')
-            expect(suggestions.value).toEqual(['Voltaire'])
+            expect(suggestions.value).toEqual(["'Voltaire'"])
         })
     })
 


### PR DESCRIPTION
since all the value aliases are strings by definition (they are key names in the dictionary), wrap them into quotes like other strings