### PR TITLE
the issue with forced blur found in DAT-56274

### DIFF
--- a/src/components/compound/DlSearches/DlSmartSearch/components/DlSmartSearchInput.vue
+++ b/src/components/compound/DlSearches/DlSmartSearch/components/DlSmartSearchInput.vue
@@ -468,13 +468,15 @@ export default defineComponent({
             emit('focus')
         }
 
-        const processBlur = () => {
+        const processBlur = (force: boolean = false) => {
             input.value.scrollLeft = 0
             input.value.scrollTop = 0
             focused.value = false
             expanded.value = true
-            updateJSONQuery()
-            emit('blur')
+            if (!force) {
+                updateJSONQuery()
+                emit('blur')
+            }
         }
 
         const blur = (
@@ -497,7 +499,7 @@ export default defineComponent({
                     return
                 }
 
-                processBlur()
+                processBlur(force)
             } else {
                 focus()
                 cancelBlur.value = cancelBlur.value - 1

--- a/tests/DlSmartSearch/DlSmartSearchInput.spec.ts
+++ b/tests/DlSmartSearch/DlSmartSearchInput.spec.ts
@@ -136,7 +136,7 @@ describe('DlSmartSearchInput', () => {
         expect(wrapper.vm.focused).toBe(true)
     })
 
-    it('should focus', () => {
+    describe('focus and blur behavior', () => {
         const wrapper = mount(DlSmartSearchInput, {
             props: {
                 disabled: false
@@ -145,19 +145,18 @@ describe('DlSmartSearchInput', () => {
                 this.$refs.input.scrollTo = vi.fn()
             }
         })
-        wrapper.vm.focus()
-        expect(wrapper.emitted().focus).toBeTruthy()
-    })
 
-    it('should handle blur', async () => {
-        const wrapper = mount(DlSmartSearchInput, {
-            mounted() {
-                this.$refs.input.scrollTo = vi.fn()
-            }
+        it('should focus', () => {
+            wrapper.vm.focus()
+            expect(wrapper.emitted().focus).toBeTruthy()
         })
-        wrapper.vm.blur()
-        expect(wrapper.emitted().blur).toBeDefined()
-        expect(wrapper.vm.focused).toBe(false)
+
+        it('should handle blur', async () => {
+            wrapper.vm.onEscapeKey()
+            wrapper.vm.blur()
+            expect(wrapper.emitted().blur).toBeDefined()
+            expect(wrapper.vm.focused).toBe(false)
+        })
     })
 
     it('should clear the value', () => {


### PR DESCRIPTION
the issue: normally we have json passed later than the component is mounted so we did not notice, but in the forced blur triggered from onMounted json was reset from the empty string 😔 

the test: blur test was actually no-op, the blur() call did not do anything at all and it only passed because 'blur' event was emitted by the forced blur earlier - combined that with focusing test + a call to onEscapeKey to close suggestions popup.