### PR TITLE
fix-774 | added tooltip in case of the longer text than the container.

### DIFF
--- a/src/components/compound/DlInput/DlInput.vue
+++ b/src/components/compound/DlInput/DlInput.vue
@@ -93,6 +93,7 @@
                                 @keydown="onKeydown"
                                 @keyup.enter="onEnterPress"
                                 @paste="handlePaste"
+                                @mouseover="onHover"
                             >
                                 <span
                                     v-if="readonly || disabled"
@@ -102,6 +103,9 @@
                                     }"
                                 >{{ spanText }}</span>
                             </div>
+                            <dl-tooltip v-if="showTooltip">
+                                {{ modelValue }}
+                            </dl-tooltip>
                             <div
                                 v-if="
                                     hasAppend ||
@@ -932,7 +936,8 @@ export default defineComponent({
             currentZoomImage: null,
             currentFile: null,
             newFileName: null,
-            focused: false
+            focused: false,
+            showTooltip: false
         }
     },
     computed: {
@@ -1110,6 +1115,14 @@ export default defineComponent({
         }
     },
     methods: {
+        onHover() {
+            const inputRef = this.$refs.input as HTMLInputElement
+            if (inputRef.scrollWidth > inputRef.clientWidth) {
+                this.showTooltip = true
+            } else {
+                this.showTooltip = false
+            }
+        },
         onKeydown(e: KeyboardEvent) {
             if (e.key !== 'Backspace') {
                 /**


### PR DESCRIPTION
added tooltip in case of the longer text than the container.
![ApplicationFrameHost_yLF7BTd6m9](https://github.com/dataloop-ai/components/assets/13769938/677fd4fb-ded3-4dcf-a95d-265c3200350e)


**Thank you for your contribution to the repo. Before submitting this PR, please make sure:**
- [X] Your code builds clean without any errors or warnings
- [X] You are using approved terminology
- [X] You have added unit tests
- [X] You have updated documentation
- [X] You have tested your changes

**Please provide a description of the changes proposed in the pull request and reference any related issues in the repository.**

**Please indicate if this PR contains:**
- [X] A bug fix
- [ ] A feature request
- [ ] Breaking changes
- [ ] An enhancement

