### PR TITLE
Dat 58089/smart search errors

### DIFF
--- a/src/components/compound/DlSearches/DlSmartSearch/components/DlSmartSearchInput.vue
+++ b/src/components/compound/DlSearches/DlSmartSearch/components/DlSmartSearchInput.vue
@@ -490,7 +490,7 @@ export default defineComponent({
             }
 
             if (cancelBlur.value === 0) {
-                if (showSuggestions.value) {
+                if (showSuggestions.value && computedStatus.value.type !== 'error') {
                     focused.value = true
                     return
                 }

--- a/src/components/compound/DlSearches/DlSmartSearch/components/DlSmartSearchInput.vue
+++ b/src/components/compound/DlSearches/DlSmartSearch/components/DlSmartSearchInput.vue
@@ -213,6 +213,10 @@ export default defineComponent({
             type: Array as PropType<string[]>,
             default: () => [] as string[]
         },
+        forbiddenKeys: {
+            type: Array as PropType<string[]>,
+            default: () => [] as string[]
+        },
         strict: {
             type: Boolean,
             default: false
@@ -245,7 +249,8 @@ export default defineComponent({
             schema,
             omitSuggestions,
             height,
-            width
+            width,
+            forbiddenKeys
         } = toRefs(props)
         //#endregion
 
@@ -269,7 +274,7 @@ export default defineComponent({
         // todo: these can be stale data. we need to update them on schema change.
         const { hasEllipsis } = useSizeObserver(input)
         const { suggestions, error, findSuggestions, checkErrors } =
-            useSuggestions(schema, aliases, { strict, omitSuggestions })
+            useSuggestions(schema, aliases, { strict, forbiddenKeys, omitSuggestions })
         //#endregion
 
         //#region methods

--- a/src/hooks/use-suggestions.ts
+++ b/src/hooks/use-suggestions.ts
@@ -410,7 +410,7 @@ const getError = (
                 return false
             }
 
-            const pattern = new RegExp(`${fieldKey}\\.\\d`)
+            const pattern = new RegExp(`^${fieldKey}\\.\\d`)
             const isValid = isInputAllowed(fieldKey, keys)
             const isForbidden = !!forbiddenKeys?.value?.includes(fieldKey)
             if (

--- a/src/hooks/use-suggestions.ts
+++ b/src/hooks/use-suggestions.ts
@@ -123,9 +123,9 @@ const mergeWords = (words: string[]) => {
 export const useSuggestions = (
     schema: Ref<Schema>,
     aliases: Ref<Alias[]>,
-    options: { strict?: Ref<boolean>; omitSuggestions?: Ref<string[]> } = {}
+    options: { strict?: Ref<boolean>; forbiddenKeys?: Ref<string[]>; omitSuggestions?: Ref<string[]> } = {}
 ) => {
-    const { strict, omitSuggestions } = options
+    const { strict, forbiddenKeys, omitSuggestions } = options
     const aliasesArray = aliases.value ?? []
     const schemaValue = schema.value ?? {}
 
@@ -159,7 +159,7 @@ export const useSuggestions = (
         const expressions = mapWordsToExpressions(mergedWords)
 
         error.value = input.length
-            ? getError(schemaValue, aliasesArray, expressions, { strict })
+            ? getError(schemaValue, aliasesArray, expressions, { strict, forbiddenKeys })
             : null
     }
 
@@ -329,7 +329,8 @@ export const useSuggestions = (
 
 const errors = {
     INVALID_EXPRESSION: 'Invalid Expression',
-    INVALID_VALUE: (field: string) => `Invalid value for "${field}" field`
+    INVALID_VALUE: (field: string) => `Invalid value for "${field}" field`,
+    FORBIDDEN_KEY: (field: string) => `Forbidden field "${field}"`
 }
 
 const isInputAllowed = (input: string, allowedKeys: string[]): boolean => {
@@ -361,9 +362,9 @@ const getError = (
     schema: Schema,
     aliases: Alias[],
     expressions: Expression[],
-    options: { strict?: Ref<boolean> } = {}
+    options: { strict?: Ref<boolean>; forbiddenKeys?: Ref<string[]>; } = {}
 ): string | null => {
-    const { strict } = options
+    const { strict, forbiddenKeys } = options
     const hasErrorInStructure = expressions
         .flatMap((exp) => Object.values(exp))
         .some((el, index, arr) => {
@@ -411,12 +412,19 @@ const getError = (
 
             const pattern = new RegExp(`${fieldKey}\\.\\d`)
             const isValid = isInputAllowed(fieldKey, keys)
+            const isForbidden = !!forbiddenKeys?.value?.includes(fieldKey)
             if (
                 !keys.includes(fieldKey) &&
                 !hasValidExpression(keys, pattern) &&
-                !isValid
+                !isValid &&
+                !isForbidden
             ) {
-                return strict.value ? errors.INVALID_EXPRESSION : 'warning'
+                return strict?.value ? errors.INVALID_EXPRESSION : 'warning'
+            }
+
+            if (isForbidden) {
+                arr.splice(1)
+                return (acc = errors.FORBIDDEN_KEY(field))
             }
 
             const valid = isValidByDataType(

--- a/src/hooks/use-suggestions.ts
+++ b/src/hooks/use-suggestions.ts
@@ -379,7 +379,7 @@ const getError = (
     return expressions
         .filter(({ field, value }) => field !== null && value !== null)
         .reduce<string | null>((acc, { field, value, operator }, _, arr) => {
-            if (acc === 'warning') return acc
+            if (acc && acc !== 'warning') return acc
             const fieldKey: string =
                 getAliasObjByAlias(aliases, field)?.key ?? field
 
@@ -438,7 +438,7 @@ const getError = (
                 return (acc = errors.INVALID_VALUE(field))
             }
 
-            return (acc = null)
+            return (acc === 'warning' ? acc : acc = null)
         }, null)
 }
 


### PR DESCRIPTION
1. Added a prop for "forbiddenKeys", to be strict on "hidden" and "type" fields.
2. Fixed a bug that caused invalid keys to be marked as warning ("type" incorrectly matched the key "mimetype.0")
3. Fixed a bug that displayed the warning instead of the error.
4. Fixed a bug that didn't show the error on focus out from the smart search.