### PR TITLE
DAT-63174: allow users to type strings without quotes

### DIFF
--- a/src/hooks/use-suggestions.ts
+++ b/src/hooks/use-suggestions.ts
@@ -505,7 +505,10 @@ const isValidByDataType = (
         case 'boolean':
             return isValidBoolean(str)
         case 'string':
-            return isValidString(str)
+            return (
+                isValidString(str) ||
+                (str && isValidString(`'${str.trim?.()}'`))
+            )
         case 'date':
         case 'datetime':
         case 'time':

--- a/tests/DlSmartSearch/DlSmartSearchInput.spec.ts
+++ b/tests/DlSmartSearch/DlSmartSearchInput.spec.ts
@@ -272,7 +272,7 @@ describe('DlSmartSearchInput', () => {
                 expect(wrapper.vm.computedStatus.type).toMatch('warning')
             })
             it('should change status to error when error state is error', async () => {
-                await wrapper.vm.debouncedSetInputValue(`name = 50`)
+                await wrapper.vm.debouncedSetInputValue(`name = '5'0`)
                 // @ts-ignore
                 await window.delay(500)
                 await wrapper.vm.$nextTick()

--- a/tests/hooks/use-suggestions.spec.ts
+++ b/tests/hooks/use-suggestions.spec.ts
@@ -259,9 +259,9 @@ describe('use-suggestions', () => {
             expect(error.value).toBe('Invalid value for "Level" field')
         })
 
-        it('should be "Invalid value for "Name" field" when the Name value does not have quotes', () => {
+        it('should be possible to type the Name value that does not have quotes', () => {
             findSuggestionsAndCheckErrors('Name = value')
-            expect(error.value).toBe('Invalid value for "Name" field')
+            expect(error.value).toBe(null)
         })
 
         it('should be "Invalid value for "Completed" field" when the is not of the correct type', () => {
@@ -270,11 +270,11 @@ describe('use-suggestions', () => {
         })
 
         describe('When using a IN operator', () => {
-            it('should be "Invalid value for "Name" field" when the values are not strings', () => {
+            it('should be possible to type the "Name" values that do not have quotes', () => {
                 findSuggestionsAndCheckErrors(`Name IN 'a', 5`)
-                expect(error.value).toBe('Invalid value for "Name" field')
+                expect(error.value).toBe(null)
             })
-            it('should be valid field" when the values are not strings', () => {
+            it('should be possible to type the "Name" values that have either single or double quotes', () => {
                 findSuggestionsAndCheckErrors(`Name IN "a", '5'`)
                 expect(error.value).toBe(null)
             })


### PR DESCRIPTION
@fadiDL https://dataloop.atlassian.net/browse/DAT-63174

the error checking generates "invalid value" error with quoteless strings, so emit('update:model-value' ...) call is blocked in updateJSONQuery and quotes arebn't added - in contrast to values listed in the search schema (these do not trigger an error when typed without quotes). so instead of failing everything they want everything to pass - correspondingly, we need to change 3 unit tests.

forceStringsType is for boolean and number values - parseSmartQuery does not know they are supposed to be strings since they come without quotes, but updateJSONQuery does know from the search schema.

let me know if you see a better solution here.