### PR TITLE
Add: feature to hide bottom side border of the inactive tabs

### DIFF
--- a/src/components/compound/DlTabs/DlTabs.vue
+++ b/src/components/compound/DlTabs/DlTabs.vue
@@ -32,15 +32,16 @@
                     :no-caps="item.noCaps"
                     :is-active="modelValue === item.name"
                     :font-size="fontSize"
+                    :hide-inactive-border-bottom="hideInactiveBorderBottom"
                     @click="handleTabClick"
                 />
             </div>
         </tabs-wrapper>
-        <div class="empty-space" />
-        <slot
-            name="top-right"
-            :styles="topRightSlotStyles"
+        <div
+            :class="{ 'no-border-bottom': hideInactiveBorderBottom }"
+            class="empty-space"
         />
+        <slot name="top-right" :styles="topRightSlotStyles" />
     </div>
 </template>
 
@@ -70,7 +71,8 @@ export default defineComponent({
         disabled: { type: Boolean, default: false },
         modelValue: { type: String, required: true },
         fontSize: { type: String, default: '18px' },
-        gap: { type: String, default: '40px' }
+        gap: { type: String, default: '40px' },
+        hideInactiveBorderBottom: { type: Boolean, default: false }
     },
     emits: ['update:model-value'],
     data() {
@@ -87,11 +89,13 @@ export default defineComponent({
     },
     computed: {
         topRightSlotStyles(): string {
-            return `border-bottom: ${
-                this.vertical
-                    ? 'inherit'
-                    : '1px solid var(--dl-color-separator)'
-            };
+            let borderBottom = this.vertical
+                ? 'inherit'
+                : '1px solid var(--dl-color-separator)'
+            if (this.hideInactiveBorderBottom) {
+                borderBottom = 'unset'
+            }
+            return `border-bottom: ${borderBottom};
             padding-left: ${this.topRightSlotWidth ? this.gap : '0px'};
             `
         },
@@ -143,7 +147,7 @@ export default defineComponent({
             this.updatePosition()
         },
         unsubscribeListeners() {
-            (this.$refs.dlTabsRef as HTMLElement)?.removeEventListener(
+            ;(this.$refs.dlTabsRef as HTMLElement)?.removeEventListener(
                 'scroll',
                 this.handleScroll
             )
@@ -246,5 +250,8 @@ export default defineComponent({
 }
 .full-width {
     width: 100%;
+}
+.no-border-bottom {
+    border-bottom: unset;
 }
 </style>

--- a/src/components/compound/DlTabs/components/DlTab.vue
+++ b/src/components/compound/DlTabs/components/DlTab.vue
@@ -49,7 +49,8 @@ export default defineComponent({
         showTooltip: { type: Boolean, default: false },
         tooltip: { type: String, default: null },
         tabindex: { type: String, default: '0' },
-        fontSize: { type: String, default: '18px' }
+        fontSize: { type: String, default: '18px' },
+        hideInactiveBorderBottom: { type: Boolean, default: false }
     },
     emits: ['click'],
     data() {
@@ -78,6 +79,8 @@ export default defineComponent({
 
             if (this.isActive) {
                 classes = classes + ' dl-tab--active'
+            } else if (this.hideInactiveBorderBottom) {
+                classes = classes + ' dl-tab--no-border-bottom'
             }
 
             if (this.disabled) {
@@ -145,6 +148,9 @@ export default defineComponent({
     &:hover {
         color: var(--dl-color-hover);
         border-color: var(--dl-color-hover);
+    }
+    &--no-border-bottom {
+        border-bottom: unset;
     }
     cursor: pointer;
     flex-grow: 1;

--- a/src/demos/DlTabsDemo.vue
+++ b/src/demos/DlTabsDemo.vue
@@ -17,6 +17,25 @@
             </dl-tab-panel>
         </dl-tab-panels>
 
+        With no border
+        <dl-tabs
+            v-model="selectedTab"
+            :items="tabItems"
+            hide-inactive-border-bottom
+            @update:model-value="handleModelValueUpdate"
+        />
+        <div style="height: 4px" />
+        <dl-tab-panels v-model="selectedTab">
+            <dl-tab-panel
+                v-for="item in tabItems"
+                :key="item.name"
+                class="tabpanel"
+                :name="item.name"
+            >
+                <h1>{{ item.label }}</h1>
+            </dl-tab-panel>
+        </dl-tab-panels>
+
         <dl-tabs
             v-model="selectedTab"
             :items="tabItems"
@@ -41,11 +60,7 @@
                         icon="icon-dl-refresh"
                         label="Refresh"
                     />
-                    <dl-button
-                        size="s"
-                        icon="icon-dl-pause"
-                        label="Pause"
-                    />
+                    <dl-button size="s" icon="icon-dl-pause" label="Pause" />
                 </div>
             </template>
         </dl-tabs>
@@ -86,11 +101,7 @@
                         icon="icon-dl-refresh"
                         label="Refresh"
                     />
-                    <dl-button
-                        size="s"
-                        icon="icon-dl-pause"
-                        label="Pause"
-                    />
+                    <dl-button size="s" icon="icon-dl-pause" label="Pause" />
                 </div>
             </template>
         </dl-tabs>

--- a/src/stories/DlTabs.stories.js
+++ b/src/stories/DlTabs.stories.js
@@ -91,6 +91,17 @@ export default {
                 type: { summary: 'array' },
                 defaultValue: { summary: defaultTabItems }
             }
+        },
+        hideInactiveBorderBottom: {
+            name: 'hideInactiveBorderBottom',
+            defaultValue: false,
+            description:
+                "Boolean value used to hide the bottom side border of the inactive tab's border",
+            control: 'boolean',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: false }
+            }
         }
     }
 }


### PR DESCRIPTION
**Thank you for your contribution to the repo. Before submitting this PR, please make sure:**
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests
- [x] You have updated documentation
- [x] You have tested your changes

**Please provide a description of the changes proposed in the pull request and reference any related issues in the repository.**
This PR adds an option for the user of the tabs component to hide the bottom border of the inactive dl-tabs.
The prop introduced is `hideInactiveBorderBottom` 
https://github.com/dataloop-ai/components/issues/827

**Please indicate if this PR contains:**
- [ ] A bug fix
- [x] A feature request
- [ ] Breaking changes
- [ ] An enhancement
