### PR TITLE
fix-828 | DlInput - cannot input < at start of text issue fix

### DIFF
--- a/src/components/compound/DlInput/DlInput.vue
+++ b/src/components/compound/DlInput/DlInput.vue
@@ -801,8 +801,8 @@ export default defineComponent({
                     if (isSpecialWord(word)) {
                         return `<span class="clickable" style="color: ${syntaxHighlightColor.value}">${word}</span>`
                     }
-                    if (word.startsWith('<')) {
-                        return `<span>${word.replace('<', '&lt;')}</span>`
+                    if (word.includes('<')) {
+                        return `<span>${word.replace(/</g, '&lt;')}</span>`
                     }
                     return word
                 })


### PR DESCRIPTION
**Thank you for your contribution to the repo. Before submitting this PR, please make sure:**
- [X] Your code builds clean without any errors or warnings
- [X] You are using approved terminology
- [X] You have added unit tests
- [X] You have updated documentation
- [X] You have tested your changes

**Please provide a description of the changes proposed in the pull request and reference any related issues in the repository.**

**Please indicate if this PR contains:**
- [X] A bug fix
- [ ] A feature request
- [ ] Breaking changes
- [ ] An enhancement
