### PR TITLE
fix-799 | fixed divider color issue

### DIFF
--- a/src/utils/getColor.ts
+++ b/src/utils/getColor.ts
@@ -9,7 +9,7 @@ const getColor = (color: string, fallback?: string) => {
         return color
     }
 
-    if (!color) return `var(--${fallback || 'dl-color-darker'})`
+    if (!color) return `var(--${fallback || 'dl-color-white'})`
     if (color.includes('var(--')) return color
 
     return `var(--${color}, var(--${fallback || 'dl-color-darker'}))`


### PR DESCRIPTION
**Thank you for your contribution to the repo. Before submitting this PR, please make sure:**
- [X] Your code builds clean without any errors or warnings
- [X] You are using approved terminology
- [X] You have added unit tests
- [X] You have updated documentation
- [X] You have tested your changes

**Please provide a description of the changes proposed in the pull request and reference any related issues in the repository.**
This issue happened because the component was not getting any value for text-color props. In that case by default it takes **dl-color-darker** Now change the default color to **dl-color-white**

![chrome_d4oHePzGyM](https://github.com/dataloop-ai/components/assets/13769938/b766c1c2-b368-4a1f-84b5-3f1497100502)

**Please indicate if this PR contains:**
- [X] A bug fix
- [ ] A feature request
- [ ] Breaking changes
- [ ] An enhancement
