### PR TITLE
DlTable > Sticky columns issues #751

### DIFF
--- a/src/components/compound/DlTable/styles/dl-table-styles.scss
+++ b/src/components/compound/DlTable/styles/dl-table-styles.scss
@@ -9,9 +9,7 @@
     }
 
     thead {
-        top: 0;
         background-color: var(--dl-color-panel-background);
-        z-index: 50;
     }
 
     .sticky-col {

--- a/src/components/compound/DlTable/styles/dl-table-styles.scss
+++ b/src/components/compound/DlTable/styles/dl-table-styles.scss
@@ -9,7 +9,6 @@
     }
 
     thead {
-        position: sticky;
         top: 0;
         background-color: var(--dl-color-panel-background);
         z-index: 50;


### PR DESCRIPTION
DlTable > Sticky columns issues #751
fix: 1.sticky columns and virtual scroll together doesn't work.
The stickiness didn't work because both the THEAD and the TH contained the definition position: sticky;
And it only had to be in TH so that the stickiness on the left and right side would also work
2.3.The solution of section 1 according to what I saw also solved this problem
4.5. I was not able to reproduce the described problem, it may also have been solved

**Thank you for your contribution to the repo. Before submitting this PR, please make sure:**
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests
- [ ] You have updated documentation
- [x] You have tested your changes

**Please provide a description of the changes proposed in the pull request and reference any related issues in the repository.**

**Please indicate if this PR contains:**
- [x] A bug fix
- [ ] A feature request
- [ ] Breaking changes
- [ ] An enhancement
