### PR TITLE
styles from DAT-65899

### DIFF
--- a/src/assets/globals.scss
+++ b/src/assets/globals.scss
@@ -86,19 +86,9 @@ body {
 }
 
 .reactive-scroll {
-    .scroll {
-        overflow: auto;
-        scrollbar-color: transparent transparent; /* For Firefox */
-    }
-    
     .scroll::-webkit-scrollbar-thumb {
-        background-color: transparent;
+        background-color: var(transparent);
     }
-    
-    .scroll:hover {
-        scrollbar-color: var(--dl-color-lighter);
-    }
-    
     .scroll:hover::-webkit-scrollbar-thumb {
         background-color: var(--dl-color-lighter);
     }


### PR DESCRIPTION
@fadiDL I think we only need to change `.scroll::-webkit-scrollbar-thumb` behavior, the rest of `.scroll` styles can just stay the same inside `.reactive-scroll`

we have no good control over firefox any way, so it's chrome only