### PR TITLE
DAT-65883: allow chevron icon inherit the text color in DlDropdownButton

### DIFF
--- a/src/components/compound/DlDropdownButton/DlDropdownButton.vue
+++ b/src/components/compound/DlDropdownButton/DlDropdownButton.vue
@@ -218,6 +218,7 @@ export default defineComponent({
         noIconAnimation: Boolean,
         disabled: Boolean,
         color: { type: String!, default: '' },
+        inheritIconColor: Boolean,
         label: { type: String, default: '' },
         textColor: { type: String!, default: '' },
         size: { type: String, default: 'm' },
@@ -393,6 +394,10 @@ export default defineComponent({
         })
 
         const getIconColor = computed(() => {
+            if (props.inheritIconColor) {
+                return null
+            }
+
             if (props.disabled) {
                 return 'dl-color-disabled'
             }

--- a/tests/DlDropdownButton.spec.ts
+++ b/tests/DlDropdownButton.spec.ts
@@ -31,6 +31,7 @@ describe('DlDropdownButton', () => {
                 icon: '',
                 label: '',
                 iconSize: '20px',
+                inheritIconColor: false,
                 mainButtonStyle: '',
                 maxHeight: null,
                 maxWidth: null,


### PR DESCRIPTION
by passing null to DlIcon's color we make it use `inherit` in the styles, thus using same color settings as its parent