### PR TITLE
DAT-67499: quick fix to selected rows background

### DIFF
--- a/src/components/blocks/DlLabelPicker/DlLabelPicker.vue
+++ b/src/components/blocks/DlLabelPicker/DlLabelPicker.vue
@@ -18,6 +18,7 @@
         </dl-input>
         <dl-tree-table
             v-if="isFilterString(inputValue)"
+            ref="table"
             draggable="none"
             separator="none"
             :hide-pagination="true"
@@ -114,7 +115,13 @@ export default defineComponent({
             items.value ? items.value[0] : null
         )
 
-        const handleRowClick = (_: MouseEvent, item: DlLabelPickerItem) => {
+        const table = ref()
+        const handleRowClick = (event: MouseEvent, item: DlLabelPickerItem) => {
+            table.value.$el
+                .querySelectorAll('tr.selected')
+                .forEach((tr: Element) => tr.classList.remove('selected'))
+            const target = event.target as Element
+            target.closest('tr').classList.add('selected')
             currentSelectedLabel.value = item
             emit('selected-label', item)
             emit('click', item)
@@ -188,6 +195,7 @@ export default defineComponent({
             placeHolderText,
             inputStyles,
             rows,
+            table,
             isFilterString
         }
     }


### PR DESCRIPTION
@fadiDL this is a simpler fix from slack convo earlier, as the built-in table selection adds checkboxes and does not make rows highlighted - aside from that there is -dl-color-fill issue (waiting for Rotem's feedback)