### PR TITLE
DAT-68110: fix onInput/debouncedSetInputValue calls

### DIFF
--- a/src/components/compound/DlSearches/DlSmartSearch/components/DlSmartSearchInput.vue
+++ b/src/components/compound/DlSearches/DlSmartSearch/components/DlSmartSearchInput.vue
@@ -672,9 +672,8 @@ export default defineComponent({
             const text = (e.target as HTMLElement).textContent
             if (text.endsWith('.') || text.endsWith(',')) {
                 setInputValue(text)
-            } else {
-                debouncedSetInputValue.value(text)
             }
+            debouncedSetInputValue.value(text)
         }
 
         const onDateSelection = (value: DateInterval) => {


### PR DESCRIPTION
@fadiDL  what happened here was when you type `n.` real quick, you get debounced called with `n` then non-debounced called with `n.` - but debounced version would actually call non-debounced after timeout thus undoing the call with `n.` (erasing the dot). by always calling debounced version we make sure that timeout-ed call with `n` does not happen - it gets replaced with the 2nd `n.` call