### PR TITLE
work around infinite scroll issue and reloading with way fewer items

### DIFF
--- a/src/components/shared/DlInfiniteScroll/DlInfiniteScroll.vue
+++ b/src/components/shared/DlInfiniteScroll/DlInfiniteScroll.vue
@@ -4,6 +4,7 @@
         class="dl-infinite-scroll"
         :style="computedStyles"
         :class="computedClasses"
+        @scrollend="onScrollEnd"
     >
         <DlTopScroll
             :container-ref="containerRef"
@@ -15,6 +16,7 @@
             </div>
         </slot>
         <DlBottomScroll
+            ref="bottomRef"
             :container-ref="containerRef"
             @scroll-to-bottom="onScrollToBottom"
         />
@@ -59,6 +61,7 @@ export default defineComponent({
     emits: ['scroll-to-top', 'scroll-to-bottom'],
     setup(props, { emit, attrs }) {
         const { items, pageSize, scrollDebounce } = toRefs(props)
+        const bottomRef = ref(null)
         const containerRef = ref(null)
         const currentPage = ref(0)
         const pagesCount = ref(0)
@@ -105,6 +108,8 @@ export default defineComponent({
                     containerRef.value.scrollTop -=
                         containerRef.value.scrollHeight * 0.333
                 }
+
+                onScrollEnd()
             })
 
             return toDisplay
@@ -112,6 +117,15 @@ export default defineComponent({
 
         const itemKey = (item: any) => {
             return item.id ?? item.key ?? JSON.stringify(item)
+        }
+
+        const onScrollEnd = () => {
+            const top =
+                bottomRef.value.$el.offsetTop - containerRef.value.scrollTop
+            if (top < containerRef.value.offsetHeight) {
+                containerRef.value.scrollTop +=
+                    top - containerRef.value.offsetHeight
+            }
         }
 
         const onScrollToTop = () => {
@@ -154,13 +168,18 @@ export default defineComponent({
                     items.value,
                     pageSize.value
                 )
+                if (!itemPages.value.get(currentPage.value)) {
+                    currentPage.value = 0
+                }
                 onScrollToTop()
             },
             { immediate: true }
         )
 
         return {
+            bottomRef,
             containerRef,
+            onScrollEnd,
             onScrollToTop,
             onScrollToBottom,
             displayItems,


### PR DESCRIPTION
@guyDataloop @fadiDL I did not find the clean solution to the scroll problem 😭 the issue is that bottom 3px detector div sometimes remains visible at the end of the scroll after the new page of items is added, thus the user needs to scroll up a bit and then again down to activate the detector - the workaround in this PR is waiting for the scrolling to end and then pushes the bottom 3px detector down so when the users scrolls again it will trigger scroll-to-bottom event as it's supposed to.

Also, the issue where you get way less items and the current page points nowhere is fixed in the same commit.