### PR TITLE
DAT-63358 Labels list- once hovering over full path is missing

### DIFF
--- a/src/components/blocks/DlLabelPicker/DlLabelPicker.vue
+++ b/src/components/blocks/DlLabelPicker/DlLabelPicker.vue
@@ -34,6 +34,7 @@
             :empty-state-props="emptyStateProps"
             :hide-bottom="hideBottom"
             :hide-no-data="hideNoData"
+            identifier-as-tooltip
             @row-click="handleRowClick"
         >
             <template #body-cell-displayLabel="item">

--- a/src/components/compound/DlTreeTable/DlTreeTable.vue
+++ b/src/components/compound/DlTreeTable/DlTreeTable.vue
@@ -537,7 +537,7 @@ export default defineComponent({
                 computedCols: tableRootRef.value.computedCols,
                 modelValue: isRowSelected(props.rowKey, getRowKey.value(row)),
                 scopedSlots: currentSlots,
-                toolTip: props.identifierAsTooltip ? row.identifier : null,
+                tooltip: props.identifierAsTooltip ? row.identifier : null,
                 'onUpdate:modelValue': (adding: boolean, evt: Event) => {
                     updateSelectionHierarchy(adding, evt, row)
                 },

--- a/src/components/compound/DlTreeTable/DlTreeTable.vue
+++ b/src/components/compound/DlTreeTable/DlTreeTable.vue
@@ -166,6 +166,13 @@ export default defineComponent({
             default: false
         },
         /**
+         * identifier As Tooltip form row object
+         */
+        identifierAsTooltip: {
+            type: Boolean,
+            default: false
+        },
+        /**
          * Function to generate the label visible when selecting rows
          */
         selectedRowsLabel: {
@@ -530,6 +537,7 @@ export default defineComponent({
                 computedCols: tableRootRef.value.computedCols,
                 modelValue: isRowSelected(props.rowKey, getRowKey.value(row)),
                 scopedSlots: currentSlots,
+                toolTip: props.identifierAsTooltip ? row.identifier : null,
                 'onUpdate:modelValue': (adding: boolean, evt: Event) => {
                     updateSelectionHierarchy(adding, evt, row)
                 },

--- a/src/components/compound/DlTreeTable/components/DlTdTree.vue
+++ b/src/components/compound/DlTreeTable/components/DlTdTree.vue
@@ -6,8 +6,8 @@
         :data-col-index="colIndex"
     >
         <slot name="icon" />
-        <dl-tooltip v-if="toolTip">
-            {{ toolTip }}
+        <dl-tooltip v-if="tooltip">
+            {{ tooltip }}
         </dl-tooltip>
         <dl-tooltip v-else-if="hasEllipsis">
             <slot />
@@ -43,7 +43,7 @@ export default defineComponent({
             type: Number,
             default: null
         },
-        toolTip: {
+        tooltip: {
             type: String,
             default: null
         }

--- a/src/components/compound/DlTreeTable/components/DlTdTree.vue
+++ b/src/components/compound/DlTreeTable/components/DlTdTree.vue
@@ -6,7 +6,10 @@
         :data-col-index="colIndex"
     >
         <slot name="icon" />
-        <dl-tooltip v-if="hasEllipsis">
+        <dl-tooltip v-if="toolTip">
+            {{ toolTip }}
+        </dl-tooltip>
+        <dl-tooltip v-else-if="hasEllipsis">
             <slot />
         </dl-tooltip>
         <slot />
@@ -38,6 +41,10 @@ export default defineComponent({
         },
         colIndex: {
             type: Number,
+            default: null
+        },
+        toolTip: {
+            type: String,
             default: null
         }
     },

--- a/src/components/compound/DlTreeTable/views/DlTrTreeView.vue
+++ b/src/components/compound/DlTreeTable/views/DlTrTreeView.vue
@@ -53,7 +53,7 @@
                     }px;`
             "
             :col-index="colIndex"
-            :tool-tip="toolTip"
+            :tooltip="tooltip"
         >
             <template v-if="!hasSlotByName(`body-cell-${col.name}`)">
                 {{ getCellValue(col, row) }}
@@ -151,7 +151,7 @@ export default defineComponent({
             type: [String, Boolean],
             default: null
         },
-        toolTip: {
+        tooltip: {
             type: String,
             default: null
         }

--- a/src/components/compound/DlTreeTable/views/DlTrTreeView.vue
+++ b/src/components/compound/DlTreeTable/views/DlTrTreeView.vue
@@ -53,6 +53,7 @@
                     }px;`
             "
             :col-index="colIndex"
+            :tool-tip="toolTip"
         >
             <template v-if="!hasSlotByName(`body-cell-${col.name}`)">
                 {{ getCellValue(col, row) }}
@@ -148,6 +149,10 @@ export default defineComponent({
         },
         modelValue: {
             type: [String, Boolean],
+            default: null
+        },
+        toolTip: {
+            type: String,
             default: null
         }
     },

--- a/src/demos/DlLabelPickerDemo.vue
+++ b/src/demos/DlLabelPickerDemo.vue
@@ -26,17 +26,17 @@ const rows: DlLabelPickerItem[] = [
         color: '#ff0000',
         children: [
             {
-                identifier: 'b',
+                identifier: 'a.a',
                 displayLabel: 'hello',
                 color: '#ffff00',
                 children: [
                     {
-                        identifier: 'c',
+                        identifier: 'a.a.a',
                         displayLabel: 'test 2',
                         color: '#00ff00',
                         children: [
                             {
-                                identifier: 'd',
+                                identifier: 'a.a.a.a',
                                 displayLabel: 'test 3',
                                 color: '#ff00aa',
                                 children: []
@@ -44,7 +44,7 @@ const rows: DlLabelPickerItem[] = [
                         ]
                     },
                     {
-                        identifier: 'd',
+                        identifier: 'a.a.b',
                         displayLabel: 'test 4',
                         color: '#ff00ff',
                         children: []

--- a/tests/DlTable/DlTable.spec.ts
+++ b/tests/DlTable/DlTable.spec.ts
@@ -152,7 +152,7 @@ describe('DlTable', () => {
             // @ts-ignore
             await window.delay(100)
             await wrapper.vm.$nextTick()
-            const newPagination = emitted['update:pagination'][1][0]
+            const newPagination = emitted['update:pagination']?.[1]?.[0]
             await wrapper.setProps({ pagination: newPagination })
             await wrapper.vm.$nextTick()
         })


### PR DESCRIPTION
Hi @fadiDL @guyDataloop 
Please review PR.

- [DAT-63358](https://dataloop.atlassian.net/browse/DAT-63358) Labels list- once hovering over full path is missing


**Thank you for your contribution to the repo. Before submitting this PR, please make sure:**
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests
- [ ] You have updated documentation
- [ ] You have tested your changes

**Please provide a description of the changes proposed in the pull request and reference any related issues in the repository.**

**Please indicate if this PR contains:**
- [ ] A bug fix
- [ ] A feature request
- [ ] Breaking changes
- [ ] An enhancement
