### PR TITLE
increase debounce timeout in DlSliderInput - fixes #790

### DIFF
--- a/src/components/compound/DlSlider/components/DlSliderInput.vue
+++ b/src/components/compound/DlSlider/components/DlSliderInput.vue
@@ -68,7 +68,7 @@ export default defineComponent({
             if (stateManager.disableDebounce) {
                 return handleChange
             }
-            return debounce(handleChange, 100)
+            return debounce(handleChange, 600)
         })
 
         return {

--- a/src/demos/DlSliderDemo.vue
+++ b/src/demos/DlSliderDemo.vue
@@ -5,7 +5,7 @@
             width="500px"
             text="slider"
             :step="1"
-            :min="-100"
+            :min="50"
             :max="100"
             :slim="slim"
             :readonly="readonly"

--- a/tests/DlSlider/DlSliderInput.spec.ts
+++ b/tests/DlSlider/DlSliderInput.spec.ts
@@ -44,7 +44,7 @@ describe('DlSliderInput', () => {
                     await sliderInput.setValue('1')
 
                     // @ts-ignore
-                    await window.delay(300)
+                    await window.delay(1000)
                     // todo: this became flaky... need to investigate
                     await wrapper.vm.$nextTick()
                 })


### PR DESCRIPTION
@advaa1234 I have increased the timeout sixfold and changed the demo to test it - seems like comfortable value, but let me know if you want something else to be done