### PR TITLE
DAT-71255: allow the slot to be created without scope.opt

### DIFF
--- a/src/components/compound/DlSearches/DlSmartSearch/components/DlSmartSearchJsonEditorDialog.vue
+++ b/src/components/compound/DlSearches/DlSmartSearch/components/DlSmartSearchJsonEditorDialog.vue
@@ -28,7 +28,7 @@
                         >
                             <template #selected="scope">
                                 <span class="json-query-menu-option">
-                                    {{ scope.opt.label }}
+                                    {{ scope.opt ? scope.opt.label : '' }}
                                 </span>
                             </template>
                             <template #option="scope">


### PR DESCRIPTION
@fadiDL this slot is created with an empty scope due to `v-if="shouldShowSelectedSlotContent"` in DlSelect:
<img width="582" alt="Screenshot 2024-05-24 at 11 05 17 AM" src="https://github.com/dataloop-ai/components/assets/146977958/f5c7ecc4-4867-4c95-ad0e-e390bd4ca8b1">
