### PR TITLE
bugfix/dat-67286-slider-input-field-resets

### DIFF
--- a/src/components/compound/DlSlider/components/DlSliderInput.vue
+++ b/src/components/compound/DlSlider/components/DlSliderInput.vue
@@ -57,11 +57,18 @@ export default defineComponent({
             const val = evt.target.value
             if (val === '') return
 
-            const { value } = getInputValue(val, props.min, props.max)
+            const { value, isUpdated } = getInputValue(
+                val,
+                props.min,
+                props.max
+            )
 
-            emit('change', Number(value))
-            emit('update:model-value', Number(value))
-            if (sliderInput.value) sliderInput.value.value = value
+            emit('change', value)
+            emit('update:model-value', value)
+
+            if (isUpdated) {
+                if (sliderInput.value) sliderInput.value.value = value
+            }
         }
 
         const debouncedHandleChange = computed(() => {

--- a/src/components/compound/DlSlider/utils.ts
+++ b/src/components/compound/DlSlider/utils.ts
@@ -1,7 +1,7 @@
 export const getInputValue = (value: string, min: number, max: number) => {
-    if (parseFloat(value) > max || parseFloat(value) < min) {
-        return { value: (parseFloat(value) > max ? max : min).toString() }
-    }
+    const numericValue = parseFloat(value)
+    const clampedValue = Math.max(min, Math.min(numericValue, max))
+    const isUpdated = numericValue !== clampedValue
 
-    return { value }
+    return { value: clampedValue.toString(), isUpdated }
 }


### PR DESCRIPTION
Issue : Due to the debouce which is set for every 100 milliseconds and also converting the value to Number before setting the value , user is not able to set decimal values or move around in the input field using left and right arrow keys.

Fix : 
The slider input field resets after a interval of 100 milliseconds , updated the code so that the ref to the input is only updated when the value is updated and not always.