### PR TITLE
DAT-73995 Marketplace Scroller - Page jump when it gets to the bottom

### DIFF
--- a/src/components/shared/DlInfiniteScroll/DlInfiniteScroll.vue
+++ b/src/components/shared/DlInfiniteScroll/DlInfiniteScroll.vue
@@ -92,18 +92,26 @@ export default defineComponent({
             } else if (nextPage?.length) {
                 toDisplay.push(...nextPage.slice(0, pageSize.value))
             }
-            const movePercent = (prevPage?.length ?? 0) / toDisplay.length
+            const prevMovePercent = (prevPage?.length ?? 0) / toDisplay.length
+            const nextMovePercent =
+                1 - (nextPage?.length ?? 0) / toDisplay.length
             nextTick(() => {
                 if (lastOp.value === 'top' && page !== 0) {
                     containerRef.value.scrollTop +=
-                        containerRef.value.scrollHeight * movePercent
+                        containerRef.value.scrollHeight * prevMovePercent
                 } else if (
                     lastOp.value === 'bottom' &&
                     page !== pagesCount.value
                 ) {
-                    if (currentPage.value - 1 === 0) {
+                    if (
+                        currentPage.value - 1 === 0 ||
+                        currentPage.value + 1 === pagesCount.value
+                    ) {
                         return
                     }
+                    containerRef.value.scrollTop =
+                        containerRef.value.scrollHeight * nextMovePercent -
+                        containerRef.value.offsetHeight
                 }
 
                 onScrollEnd()


### PR DESCRIPTION
Hi @guyDataloop 
Please review PR.

- [DAT-73995](https://dataloop.atlassian.net/browse/DAT-73995) Marketplace Scroller - Page jump when it gets to the bottom

**Constraint**: When reaching the deep bottom and then scrolling up or down, there might be slight movement because if we have three columns, and the last row contains only one or two items, it can cause slight up or down movement.

Thank you

**Thank you for your contribution to the repo. Before submitting this PR, please make sure:**
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests
- [ ] You have updated documentation
- [ ] You have tested your changes

**Please provide a description of the changes proposed in the pull request and reference any related issues in the repository.**

**Please indicate if this PR contains:**
- [ ] A bug fix
- [ ] A feature request
- [ ] Breaking changes
- [ ] An enhancement
