### PR TITLE
DAT-74829: re-fix #781

### DIFF
--- a/src/components/compound/DlSearches/DlSmartSearch/components/SuggestionsDropdown.vue
+++ b/src/components/compound/DlSearches/DlSmartSearch/components/SuggestionsDropdown.vue
@@ -122,8 +122,12 @@ export default defineComponent({
         const setHighlightedIndex = (value: any) => {
             highlightedIndex.value = value
 
+            const portalEl =
+                typeof menu.value?.portalEl === 'string'
+                    ? document.querySelector(menu.value.portalEl)
+                    : menu.value?.portalEl
             const element =
-                menu.value?.portalEl.querySelectorAll?.('.dl-list-item')[value]
+                portalEl?.querySelectorAll?.('.dl-list-item')[value]
             if (element) {
                 if (element.scrollIntoViewIfNeeded) {
                     element.scrollIntoViewIfNeeded()


### PR DESCRIPTION
@guyDataloop so what actually happened was that automatic scrolling (from #781) was broken completely when someone returned a selector string instead of actual portalEl for vue2 (which is what OA is using) 😔