### PR TITLE
fix table column widths

### DIFF
--- a/src/utils/table-columns.ts
+++ b/src/utils/table-columns.ts
@@ -163,7 +163,7 @@ export function setAllColumnWidths(
                         getIconWidth(targetEl) +
                         35
                     // Set the width of the column
-                    targetEl.style.minWidth =
+                    targetEl.style.width =
                         typeof col.width === 'number' || !col.width
                             ? `${width}px`
                             : col.width


### PR DESCRIPTION
According to [SO](https://stackoverflow.com/a/6427041),
> For table cells the 'width' property should be used, as the 'min-width' and 'max-width' is undefined for table cells.

At the moment, `minWidth` has no effect in chrome. This is the table before the fix:
<img width="1355" alt="Screenshot 2024-11-13 at 2 40 01 PM" src="https://github.com/user-attachments/assets/c7a43902-0d8a-4fec-ba53-5e2c85d0e302">

And this is the same table after the fix:
<img width="1332" alt="Screenshot 2024-11-13 at 2 39 06 PM" src="https://github.com/user-attachments/assets/4a32d9d2-e769-4cf0-84a8-f7aa4842ee17">
