### PR TITLE
DAT-84082-treetable-customizing-no-data-slot

### DIFF
--- a/src/components/compound/DlTreeTable/DlTreeTable.vue
+++ b/src/components/compound/DlTreeTable/DlTreeTable.vue
@@ -904,7 +904,9 @@ export default defineComponent({
                         },
                         (): [] => []
                     ),
-                tbody
+                tbody,
+                'no-data':
+                    this.$slots['no-data'] || (() => this.renderEmptyState())
             }
         })
     }


### PR DESCRIPTION
Not able to modify the slot of no-data on dl-tree-table .

Issue:
The issue was dl-tree-table component did not expose the no-data slot to dl-table.
Even though dl-table supports a no-data slot, dl-tree-table wasn't passing it through

Fix:
We exposed the no-data slot from dl-tree-table to dl-table.