### PR TITLE
DAT-88102 fix the whitespace in DlTooltip

### DIFF
--- a/src/components/shared/DlTooltip/DlTooltip.vue
+++ b/src/components/shared/DlTooltip/DlTooltip.vue
@@ -445,7 +445,9 @@ export default defineComponent({
     word-break: break-word;
     pointer-events: none;
 }
-
+.capitalize {
+    white-space-collapse: collapse;
+}
 .capitalize::first-letter {
     text-transform: var(--dl-tooltip-text-transform);
 }


### PR DESCRIPTION
Before:
<img width="181" alt="Screenshot 2025-02-21 at 3 39 19 PM" src="https://github.com/user-attachments/assets/1cba58f2-f6fd-4aa6-b5a0-da3b983f0e41" />
After:
<img width="180" alt="Screenshot 2025-02-21 at 3 40 05 PM" src="https://github.com/user-attachments/assets/73e1a17e-0fb7-4151-b91c-a16b6e572078" />
