### PR TITLE
DAT-94742-Label-Picker-Changes

### DIFF
--- a/src/components/blocks/DlLabelPicker/DlLabelPicker.vue
+++ b/src/components/blocks/DlLabelPicker/DlLabelPicker.vue
@@ -232,10 +232,18 @@ export default defineComponent({
 
                 if (item.displayLabel === displayLabel) {
                     currentSelectedLabel.value = item
+                    emit('selected-label', item)
 
                     nextTick(() => {
-                        const simulatedClickEvent = new MouseEvent('click')
-                        handleRowClick(simulatedClickEvent, item)
+                        const target = table.value?.$el.querySelector(
+                            `[data-label-picker-identifier="${item.identifier}"]`
+                        )
+                        table.value?.$el
+                            .querySelectorAll('tr.selected')
+                            .forEach((tr: Element) =>
+                                tr.classList.remove('selected')
+                            )
+                        target?.closest('tr')?.classList.add('selected')
                     })
                     return
                 }


### PR DESCRIPTION
Changed the code a bit ,  incase of  handleRowClick(simulatedClickEvent, item) , since we were giving a dummyClick mouseEvent. , target would be null and it would throw an error and the emits are not triggered 
                        