### PR TITLE
DAT-84173-Dl-Button-add-prop-change-color-on-press

### DIFF
--- a/src/components/basic/DlButton/DlButton.vue
+++ b/src/components/basic/DlButton/DlButton.vue
@@ -195,7 +195,7 @@ export default defineComponent({
         /**
          * Overwrite default background color on mouse press
          */
-        pressedBgColor: { type: String, default: null },
+        pressedBgColor: { type: String, default: null, required: false },
         /**
          * Overwrite default border color on hover
          */

--- a/src/components/basic/DlButton/DlButton.vue
+++ b/src/components/basic/DlButton/DlButton.vue
@@ -193,6 +193,10 @@ export default defineComponent({
          */
         hoverBgColor: { type: String, default: null },
         /**
+         * Overwrite default background color on mouse press
+         */
+        pressedBgColor: { type: String, default: null },
+        /**
          * Overwrite default border color on hover
          */
         hoverBorderColor: { type: String, default: null },
@@ -404,10 +408,13 @@ export default defineComponent({
                         shaded: this.shaded,
                         outlined: this.shaded
                     }),
-                    '--dl-button-bg-pressed': setBgOnPressed({
-                        shaded: this.shaded,
-                        outlined: this.outlined
-                    }),
+                    '--dl-button-bg-pressed':
+                        this.pressedBgColor ??
+                        setBgOnPressed({
+                            shaded: this.shaded,
+                            outlined: this.outlined
+                        }),
+
                     '--dl-button-border-pressed': setBorderOnPressed({
                         shaded: this.shaded,
                         outlined: this.outlined

--- a/tests/DlButton.spec.ts
+++ b/tests/DlButton.spec.ts
@@ -46,7 +46,8 @@ describe('DlButton', () => {
                 tooltipTriggerPercentage: 1,
                 hoverBgColor: null,
                 hoverBorderColor: null,
-                hoverTextColor: null
+                hoverTextColor: null,
+                pressedBgColor: null
             })
         })
     })


### PR DESCRIPTION
Added pressedBgColor prop in dl-button , so that we can customize the bg-color in button press.