### PR TITLE
DAT-98709-chevron-issue-dl-tree-table

### DIFF
--- a/src/components/compound/DlTreeTable/views/DlTrTreeView.vue
+++ b/src/components/compound/DlTreeTable/views/DlTrTreeView.vue
@@ -47,8 +47,14 @@
                 />
             </slot>
         </td>
-        <td class="chevron-icon-container">
-            <div class="chevron-icon">
+        <td
+            class="chevron-icon-container"
+            :class="{ 'no-children': (row.children || []).length === 0 }"
+        >
+            <div
+                class="chevron-icon"
+                :class="{ 'no-children': (row.children || []).length === 0 }"
+            >
                 <DlIcon
                     v-if="(row.children || []).length > 0"
                     :icon="`${
@@ -67,13 +73,13 @@
             :class="col.tdClass(row)"
             :style="
                 col.tdStyle(row) +
-                    `padding-left: ${
-                        setTrPadding(
-                            level,
-                            (row.children || []).length > 0,
-                            colIndex
-                        ) + 1
-                    }px;`
+                `padding-left: ${
+                    setTrPadding(
+                        level,
+                        (row.children || []).length > 0,
+                        colIndex
+                    ) + 1
+                }px;`
             "
             :col-index="colIndex"
             :tooltip="tooltip"
@@ -432,9 +438,17 @@ export default defineComponent({
     cursor: pointer;
     padding: 5px;
     height: 100%;
+
+    &.no-children {
+        cursor: default;
+    }
 }
 .chevron-icon-container {
     cursor: pointer;
     width: 25px;
+
+    &.no-children {
+        cursor: default;
+    }
 }
 </style>


### PR DESCRIPTION
Previously, the mouse cursor was set to pointer on the chevron div regardless of whether a sub-label (and therefore a chevron) was present. 

Fix:
Updated logic to ensure that the mouse cursor is set to pointer only when the chevron is rendered (i.e., when a sub-label exists).

