### PR TITLE
Disable Draggable icon for system labels and disable checkbox for sys…

### DIFF
--- a/src/components/compound/DlTreeTable/views/DlTrTreeView.vue
+++ b/src/components/compound/DlTreeTable/views/DlTrTreeView.vue
@@ -17,6 +17,7 @@
             }`"
         >
             <dl-icon
+                v-if="!row.disableDraggable"
                 class="draggable-icon"
                 icon="icon-dl-drag"
                 size="12px"
@@ -40,7 +41,7 @@
                     :indeterminate-value="true"
                     :false-value="false"
                     :true-value="true"
-                    :disabled="isCheckboxDisabled"
+                    :disabled="isCheckboxDisabled || !row.isSelectable"
                     @update:model-value="
                         (adding, evt) => emitUpdateModelValue(adding, evt)
                     "


### PR DESCRIPTION
The draggable icon now only shows if the row isn't a system label, to keep the behavior where system labels can't be dragged. Also added a check to prevent system labels from being selectable.