### PR TITLE
remove duplicated color from theme.css

### DIFF
--- a/src/assets/theme.css
+++ b/src/assets/theme.css
@@ -120,7 +120,6 @@ body {
     --dl-color-hover: #aeb9ff;
     --dl-color-disabled: #ffffff40;
     --dl-color-fill: #ffffff1e;
-    --dl-color-fill-secondary: #f8f8f81a;
     --dl-color-fill-hover: #454a50;
     --dl-color-separator: #ffffff26;
     --dl-color-component: #30363d;


### PR DESCRIPTION
it was followed below by redeclaration to #ffffff1a (which Liran says is correct)
