### PR TITLE
#1058 / DAT- 89965 | DlDropdown-extend-icon-customization

### DIFF
--- a/src/components/compound/DlDropdownButton/DlDropdownButton.vue
+++ b/src/components/compound/DlDropdownButton/DlDropdownButton.vue
@@ -64,6 +64,8 @@
                 :icon="dropdownIcon"
                 :size="iconSize"
                 :color="getIconColor"
+                :tooltip="iconTooltip"
+                @click="onClickIcon"
             />
         </dl-button>
         <dl-menu
@@ -132,6 +134,8 @@
                 :icon="dropdownIcon"
                 :size="iconSize"
                 :color="getIconColor"
+                :tooltip="iconTooltip"
+                @click="onClickIcon"
             />
         </div>
 
@@ -235,6 +239,11 @@ export default defineComponent({
         fluid: Boolean,
         icon: { type: String, required: false, default: '' },
         iconSize: { type: String, required: false, default: '20px' },
+        iconTooltip: {
+            type: String,
+            required: false,
+            default: null
+        },
         flat: Boolean,
         transform: {
             type: String as PropType<DlTextTransformOptions>,
@@ -276,6 +285,7 @@ export default defineComponent({
         'update:model-value',
         'update:model-value',
         'click',
+        'icon-clicked',
         'before-show',
         'show',
         'before-hide',
@@ -384,6 +394,10 @@ export default defineComponent({
             emit('click', e)
         }
 
+        function onClickIcon(e: Event) {
+            emit('icon-clicked', e)
+        }
+
         function onClickHide(e: Event) {
             stop(e)
             hide(e)
@@ -486,6 +500,7 @@ export default defineComponent({
             onShow,
             onHide,
             onClick,
+            onClickIcon,
             onClickHide,
             toggle,
             show,

--- a/src/components/essential/DlIcon/DlIcon.vue
+++ b/src/components/essential/DlIcon/DlIcon.vue
@@ -18,6 +18,9 @@
             {{ externalIcon ? icon : null }}
         </i>
         <slot />
+        <dl-tooltip v-if="tooltip">
+            {{ tooltip }}
+        </dl-tooltip>
     </div>
     <div
         v-else
@@ -48,9 +51,13 @@ import {
 } from 'vue-demi'
 import { getColor, loggerFactory, stringStyleToRecord } from '../../../utils'
 import { COLORED_ICONS } from '@dataloop-ai/icons/types'
+import { DlTooltip } from '../../shared'
 
 export default defineComponent({
     name: 'DlIcon',
+    components: {
+        DlTooltip
+    },
     props: {
         color: {
             type: String,
@@ -79,11 +86,15 @@ export default defineComponent({
         svgSource: {
             type: String,
             default: null
+        },
+        tooltip: {
+            type: String,
+            default: null
         }
     },
     emits: ['click', 'mousemove', 'mouseup', 'mousedown'],
     setup(props) {
-        const { styles, color, size, icon, svg, inline, svgSource } =
+        const { styles, color, size, icon, svg, inline, svgSource, tooltip } =
             toRefs(props)
 
         const svgIcon = ref(null)


### PR DESCRIPTION
Icon Slot – Add support for displaying a tooltip.
DlDropdown – When the dropdown icon slot is clicked, emit the event.

**Thank you for your contribution to the repo. Before submitting this PR, please make sure:**
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests
- [ ] You have updated documentation
- [ ] You have tested your changes

**Please provide a description of the changes proposed in the pull request and reference any related issues in the repository.**

**Please indicate if this PR contains:**
- [ ] A bug fix
- [ ] A feature request
- [ ] Breaking changes
- [ ] An enhancement
