### PR TITLE
DAT-137758/Long-text-breaks-inputs-fields

### DIFF
--- a/src/components/compound/DlInput/DlInput.vue
+++ b/src/components/compound/DlInput/DlInput.vue
@@ -1664,6 +1664,7 @@ export default defineComponent({
         position: relative;
         line-height: 10px;
         width: 100%;
+        contain: inline-size;
 
         &--text-color {
             color: var(--dell-gray-800);

--- a/src/components/compound/DlInput/DlInput.vue
+++ b/src/components/compound/DlInput/DlInput.vue
@@ -212,32 +212,40 @@
                                             :src="item.image"
                                             class="dl-input__suggestion--image"
                                         />
-                                        <span
-                                            v-for="(
-                                                word, index
-                                            ) in getSuggestWords(
-                                                item.suggestion,
-                                                modelValue
-                                            )"
-                                            :key="JSON.stringify(word) + index"
-                                            :class="{
-                                                'dl-input__suggestion--highlighted':
-                                                    word.highlighted
-                                            }"
+                                        <dl-ellipsis
+                                            class="dl-input__suggestion--text"
                                         >
-                                            <span v-if="word.value[0] === ' '"
-                                            >&nbsp;</span
-                                            >
-                                            {{ word.value }}
                                             <span
-                                                v-if="
-                                                    word.value[
-                                                        word.value.length - 1
-                                                    ] === ' '
+                                                v-for="(
+                                                    word, index
+                                                ) in getSuggestWords(
+                                                    item.suggestion,
+                                                    modelValue
+                                                )"
+                                                :key="
+                                                    JSON.stringify(word) + index
                                                 "
-                                            >&nbsp;</span
+                                                :class="{
+                                                    'dl-input__suggestion--highlighted':
+                                                        word.highlighted
+                                                }"
                                             >
-                                        </span>
+                                                <span
+                                                    v-if="word.value[0] === ' '"
+                                                >&nbsp;</span
+                                                >
+                                                {{ word.value }}
+                                                <span
+                                                    v-if="
+                                                        word.value[
+                                                            word.value.length -
+                                                            1
+                                                        ] === ' '
+                                                    "
+                                                >&nbsp;</span
+                                                >
+                                            </span>
+                                        </dl-ellipsis>
                                     </slot>
                                 </dl-list-item>
                             </dl-list>
@@ -1797,6 +1805,14 @@ export default defineComponent({
             background-color: var(--dl-color-warning);
             border-radius: 2px;
             color: var(--dl-color-text-darker-buttons);
+        }
+        &--text {
+            flex: 1 1 auto;
+            min-width: 0;
+
+            ::v-deep .dl-ellipsis__left {
+                white-space: nowrap;
+            }
         }
         &--image {
             margin-right: 5px;

--- a/src/demos/DlInputDemo.vue
+++ b/src/demos/DlInputDemo.vue
@@ -290,6 +290,11 @@ export default defineComponent({
             {
                 suggestion: '@team-design',
                 startIcon: 'icon-dl-users'
+            },
+            {
+                suggestion:
+                    'averyveryveryveryveryveryveryverylongtextwithoutanyspaces',
+                startIcon: 'icon-dl-users'
             }
         ])
 


### PR DESCRIPTION
**Root Cause**
DlInput uses a contenteditable div (for inline highlighting + expandable text) instead of a native <input>. A contenteditable is sized by its content, and with white-space: nowrap its min-content width = the whole typed string. Since every flex ancestor has the default min-width: auto (= min-content), nothing could shrink — so the field stretched wider than its container as you typed. DlTextInput doesn't do this because a native <input> never grows to its value.

**Fix**
Add contain: inline-size to .dl-input__input:

It makes the browser compute the element's horizontal size from width only, ignoring its text — so the field can't stretch itself or its ancestors (text just clips via the existing overflow: hidden). Only the inline axis is contained, so expandable/multiline still grows vertically. No layout side effects (size containment doesn't create a containing block/stacking context), and it's Baseline-supported since 2022.

---

**Thank you for your contribution to the repo. Before submitting this PR, please make sure:**
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests
- [x] You have updated documentation
- [ ] You have tested your changes

**Please provide a description of the changes proposed in the pull request and reference any related issues in the repository.**

**Please indicate if this PR contains:**
- [x] A bug fix
- [ ] A feature request
- [ ] Breaking changes
- [ ] An enhancement
